### PR TITLE
Rebrand to GEI and update site switcher to show names

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -63,12 +63,11 @@ export default function LoginPage() {
         {/* Brand lockup — monospace wordmark doing double duty as a logo. */}
         <div className="mb-8 flex items-baseline gap-2">
           <span className="text-primary font-mono text-2xl font-bold tracking-tight">GEI</span>
-          <span className="text-muted-foreground text-sm font-medium">inventory</span>
         </div>
 
         <h1 className="mb-1 text-lg font-semibold">Sign in</h1>
         <p className="text-muted-foreground mb-6 text-sm">
-          Continue to your assigned sites and inventory.
+          Continue to your assigned sites.
         </p>
 
         <Button className="w-full" onClick={onGoogle}>
@@ -148,7 +147,7 @@ export default function LoginPage() {
       </div>
 
       <p className="text-muted-foreground mt-6 text-xs">
-        GEI Inventory · multi-site, role-scoped, audited
+        GEI · multi-site, role-scoped, audited
       </p>
     </main>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,10 +14,10 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: 'GEI Inventory',
-    template: '%s — GEI Inventory',
+    default: 'GEI',
+    template: '%s — GEI',
   },
-  description: 'Multi-site construction inventory management for GEI.',
+  description: 'Multi-site construction management for GEI.',
 };
 
 export default function RootLayout({

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -56,7 +56,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <div className="flex items-center gap-5">
           <Link href="/dashboard" className="flex items-baseline gap-1.5">
             <span className="text-primary font-mono text-base font-bold tracking-tight">GEI</span>
-            <span className="text-muted-foreground text-xs font-medium">inventory</span>
           </Link>
           <SiteSwitcher />
         </div>

--- a/components/site-switcher.tsx
+++ b/components/site-switcher.tsx
@@ -52,7 +52,7 @@ export function SiteSwitcher() {
       <SelectContent>
         {sites.map((s) => (
           <SelectItem key={s.id} value={s.id}>
-            {s.code} — {s.name}
+            {s.name}
           </SelectItem>
         ))}
       </SelectContent>


### PR DESCRIPTION
This change updates the application's branding to use "GEI" instead of "GEI inventory" across the metadata, app shell, and login page. It also updates the site switcher to display the site name instead of the site code/UUID, fulfilling the user's request for a cleaner and more generalized branding as the app expands beyond just inventory management.

Fixes #5

---
*PR created automatically by Jules for task [7764096049801376344](https://jules.google.com/task/7764096049801376344) started by @shubhambansal013*