### PR TITLE
Rename IN/OUT to PURCHASE and ISSUE terminology

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -156,7 +156,7 @@ export default async function DashboardPage() {
   // Recent 10 transactions (merge + sort)
   type Recent = {
     id: string;
-    type: 'IN' | 'OUT';
+    type: 'PURCHASE' | 'ISSUE';
     date: string;
     qty: number;
     itemCode: string;
@@ -168,7 +168,7 @@ export default async function DashboardPage() {
     ...(recentIn ?? []).map(
       (p): Recent => ({
         id: p.id,
-        type: 'IN',
+        type: 'PURCHASE',
         date: p.receipt_date,
         qty: p.received_qty,
         itemCode: p.item?.code ?? '',
@@ -180,7 +180,7 @@ export default async function DashboardPage() {
     ...(recentOut ?? []).map(
       (i): Recent => ({
         id: i.id,
-        type: 'OUT',
+        type: 'ISSUE',
         date: i.issue_date,
         qty: i.qty,
         itemCode: i.item?.code ?? '',
@@ -352,7 +352,7 @@ export default async function DashboardPage() {
                   <td className="py-1.5">
                     <span
                       className={
-                        r.type === 'IN'
+                        r.type === 'PURCHASE'
                           ? 'text-primary font-semibold'
                           : 'font-semibold text-emerald-700'
                       }

--- a/app/(app)/inventory/item/[id]/item-ledger-client.tsx
+++ b/app/(app)/inventory/item/[id]/item-ledger-client.tsx
@@ -40,7 +40,7 @@ type IssueRow = {
 type LedgerRow = {
   id: string;
   date: string;
-  type: 'IN' | 'OUT';
+  type: 'PURCHASE' | 'ISSUE';
   qtyIn: number | null;
   qtyOut: number | null;
   balance: number;
@@ -69,7 +69,7 @@ export function ItemLedgerClient({ item, purchases, issues }: Props) {
     const ins: LedgerRow[] = purchases.map((p) => ({
       id: `P-${p.id}`,
       date: p.receipt_date,
-      type: 'IN',
+      type: 'PURCHASE',
       qtyIn: p.stock_qty ?? p.received_qty,
       qtyOut: null,
       balance: 0,
@@ -80,7 +80,7 @@ export function ItemLedgerClient({ item, purchases, issues }: Props) {
     const outs: LedgerRow[] = issues.map((i) => ({
       id: `I-${i.id}`,
       date: i.issue_date,
-      type: 'OUT',
+      type: 'ISSUE',
       qtyIn: null,
       qtyOut: i.qty,
       balance: 0,
@@ -110,10 +110,12 @@ export function ItemLedgerClient({ item, purchases, issues }: Props) {
       accessorKey: 'type',
       header: 'Type',
       cell: ({ getValue }) => {
-        const v = getValue() as 'IN' | 'OUT';
+        const v = getValue() as 'PURCHASE' | 'ISSUE';
         return (
           <span
-            className={v === 'IN' ? 'text-primary font-medium' : 'font-medium text-emerald-700'}
+            className={
+              v === 'PURCHASE' ? 'text-primary font-medium' : 'font-medium text-emerald-700'
+            }
           >
             {v}
           </span>
@@ -122,7 +124,7 @@ export function ItemLedgerClient({ item, purchases, issues }: Props) {
     },
     {
       accessorKey: 'qtyIn',
-      header: 'Qty in',
+      header: 'Purchase qty',
       cell: ({ getValue }) => {
         const v = getValue() as number | null;
         return <span className="block text-right tabular-nums">{v != null ? v : ''}</span>;
@@ -130,7 +132,7 @@ export function ItemLedgerClient({ item, purchases, issues }: Props) {
     },
     {
       accessorKey: 'qtyOut',
-      header: 'Qty out',
+      header: 'Issue qty',
       cell: ({ getValue }) => {
         const v = getValue() as number | null;
         return <span className="block text-right tabular-nums">{v != null ? v : ''}</span>;
@@ -162,8 +164,8 @@ export function ItemLedgerClient({ item, purchases, issues }: Props) {
   const exportCols: { key: keyof LedgerRow; header: string; numFmt?: string }[] = [
     { key: 'date', header: 'Date' },
     { key: 'type', header: 'Type' },
-    { key: 'qtyIn', header: 'Qty in', numFmt: '#,##0.00' },
-    { key: 'qtyOut', header: 'Qty out', numFmt: '#,##0.00' },
+    { key: 'qtyIn', header: 'Purchase qty', numFmt: '#,##0.00' },
+    { key: 'qtyOut', header: 'Issue qty', numFmt: '#,##0.00' },
     { key: 'balance', header: 'Balance', numFmt: '#,##0.00' },
     { key: 'party', header: 'Party / Location' },
     { key: 'rate', header: 'Rate', numFmt: '₹#,##,##0.00' },

--- a/app/(app)/inventory/transactions/edit-dialog.tsx
+++ b/app/(app)/inventory/transactions/edit-dialog.tsx
@@ -16,7 +16,7 @@ import { editPurchase, editIssue } from './actions';
 
 export type EditTarget = {
   id: string;
-  type: 'IN' | 'OUT';
+  type: 'PURCHASE' | 'ISSUE';
   currentQty: number;
   currentRef: string;
 };
@@ -28,9 +28,9 @@ type Props = {
 };
 
 /**
- * Form dialog for editing a purchase (IN) or issue (OUT). Only the
- * handful of safe-to-edit columns are exposed — quantity and the ref
- * field (invoice # for IN, issued-to for OUT). Reason is required
+ * Form dialog for editing a purchase or issue. Only the handful of
+ * safe-to-edit columns are exposed — quantity and the ref field
+ * (invoice # for purchase, issued-to for issue). Reason is required
  * because `editPurchase`/`editIssue` set `SET LOCAL app.edit_reason`
  * and the audit trigger writes before/after JSONB into
  * `inventory_edit_log`.
@@ -46,7 +46,7 @@ export function EditDialog({ target, onOpenChange, onSuccess }: Props) {
   const [pending, startTransition] = useTransition();
 
   const canSubmit = reason.trim().length > 0 && !pending;
-  const isIn = target?.type === 'IN';
+  const isPurchase = target?.type === 'PURCHASE';
 
   const handle = () => {
     if (!target || !canSubmit) return;
@@ -56,7 +56,7 @@ export function EditDialog({ target, onOpenChange, onSuccess }: Props) {
       // columns the user didn't touch.
       const qtyChanged = qty !== String(target.currentQty);
       const refChanged = ref !== target.currentRef;
-      const payload = isIn
+      const payload = isPurchase
         ? {
             id: target.id,
             reason: reason.trim(),
@@ -69,7 +69,7 @@ export function EditDialog({ target, onOpenChange, onSuccess }: Props) {
             ...(qtyChanged ? { qty } : {}),
             ...(refChanged ? { issued_to_legacy: ref || null } : {}),
           };
-      const res = isIn ? await editPurchase(payload) : await editIssue(payload);
+      const res = isPurchase ? await editPurchase(payload) : await editIssue(payload);
       if (res.ok) {
         toast.success('Saved. Audit log captured the reason.');
         onSuccess();
@@ -83,10 +83,10 @@ export function EditDialog({ target, onOpenChange, onSuccess }: Props) {
     <Dialog open={target !== null} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Edit {isIn ? 'purchase' : 'issue'} transaction</DialogTitle>
+          <DialogTitle>Edit {isPurchase ? 'purchase' : 'issue'} transaction</DialogTitle>
           <p className="text-muted-foreground text-sm">
-            Only qty and {isIn ? 'invoice #' : 'issued-to'} can be edited inline. For destination
-            changes, soft-delete and re-enter.
+            Only qty and {isPurchase ? 'invoice #' : 'issued-to'} can be edited inline. For
+            destination changes, soft-delete and re-enter.
           </p>
         </DialogHeader>
 
@@ -105,7 +105,7 @@ export function EditDialog({ target, onOpenChange, onSuccess }: Props) {
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="edit-ref">{isIn ? 'Invoice #' : 'Issued to'}</Label>
+            <Label htmlFor="edit-ref">{isPurchase ? 'Invoice #' : 'Issued to'}</Label>
             <Input id="edit-ref" value={ref} onChange={(e) => setRef(e.target.value)} />
           </div>
 

--- a/app/(app)/inventory/transactions/transactions-client.tsx
+++ b/app/(app)/inventory/transactions/transactions-client.tsx
@@ -18,12 +18,12 @@ import { EditDialog, type EditTarget } from './edit-dialog';
 
 /**
  * A unified row shape that both purchases and issues flatten into.
- * `type: 'IN'` reads amber for purchases, `'OUT'` reads green for issues
+ * `type: 'PURCHASE'` reads amber for purchases, `'ISSUE'` reads green for issues
  * (semantic use of accent vs. chart-3).
  */
 type UnifiedRow = {
   id: string;
-  type: 'IN' | 'OUT';
+  type: 'PURCHASE' | 'ISSUE';
   date: string;
   itemId: string;
   itemCode: string;
@@ -67,14 +67,14 @@ export function TransactionsClient({ purchases, issues }: Props) {
   const router = useRouter();
   const [, startTransition] = useTransition();
   const [search, setSearch] = useState('');
-  const [typeFilter, setTypeFilter] = useState<'ALL' | 'IN' | 'OUT'>('ALL');
-  const [deleteTarget, setDeleteTarget] = useState<{ id: string; type: 'IN' | 'OUT' } | null>(null);
+  const [typeFilter, setTypeFilter] = useState<'ALL' | 'PURCHASE' | 'ISSUE'>('ALL');
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; type: 'PURCHASE' | 'ISSUE' } | null>(null);
   const [editTarget, setEditTarget] = useState<EditTarget | null>(null);
 
   const rows = useMemo<UnifiedRow[]>(() => {
     const inRows: UnifiedRow[] = purchases.map((p) => ({
       id: p.id,
-      type: 'IN',
+      type: 'PURCHASE',
       date: p.receipt_date,
       itemId: p.item?.id ?? '',
       itemCode: p.item?.code ?? '',
@@ -90,7 +90,7 @@ export function TransactionsClient({ purchases, issues }: Props) {
       const dest = i.location?.full_path ?? i.party?.name ?? (i.dest ? `→ ${i.dest.code}` : '—');
       return {
         id: i.id,
-        type: 'OUT',
+        type: 'ISSUE',
         date: i.issue_date,
         itemId: i.item?.id ?? '',
         itemCode: i.item?.code ?? '',
@@ -126,12 +126,12 @@ export function TransactionsClient({ purchases, issues }: Props) {
       accessorKey: 'type',
       header: 'Type',
       cell: ({ getValue }) => {
-        const v = getValue() as 'IN' | 'OUT';
+        const v = getValue() as 'PURCHASE' | 'ISSUE';
         return (
           <Badge
             variant="outline"
             className={
-              v === 'IN'
+              v === 'PURCHASE'
                 ? 'border-primary/50 text-primary bg-primary/5'
                 : 'border-emerald-500/50 bg-emerald-500/5 text-emerald-700'
             }
@@ -247,7 +247,7 @@ export function TransactionsClient({ purchases, issues }: Props) {
           className="max-w-xs"
         />
         <div className="flex gap-1 rounded-sm border p-0.5">
-          {(['ALL', 'IN', 'OUT'] as const).map((t) => (
+          {(['ALL', 'PURCHASE', 'ISSUE'] as const).map((t) => (
             <button
               key={t}
               type="button"
@@ -302,7 +302,7 @@ export function TransactionsClient({ purchases, issues }: Props) {
         confirmLabel="Delete"
         onConfirm={async (reason) => {
           if (!deleteTarget || !reason) return;
-          const fn = deleteTarget.type === 'IN' ? softDeletePurchase : softDeleteIssue;
+          const fn = deleteTarget.type === 'PURCHASE' ? softDeletePurchase : softDeleteIssue;
           const res = await fn({ id: deleteTarget.id, reason });
           if (res.ok) {
             toast.success('Transaction deleted.');

--- a/app/(app)/reports/items/items-report-client.tsx
+++ b/app/(app)/reports/items/items-report-client.tsx
@@ -166,7 +166,7 @@ export function ItemsReportClient({ rows }: Props) {
           title={rows.length === 0 ? 'No stock movements yet' : 'Nothing matches your search'}
           description={
             rows.length === 0
-              ? 'Record an inward transaction; the report populates on the next load.'
+              ? 'Record a purchase transaction; the report populates on the next load.'
               : 'Try a different code or name.'
           }
         />

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -118,9 +118,9 @@ test.describe('golden path — purchase → issue → ledger balance', () => {
     await page.getByRole('button', { name: 'Record purchase' }).click();
     await page.waitForURL(/\/inventory\/transactions/, { timeout: 15_000 });
 
-    // The new row appears — first row should be our IN transaction
+    // The new row appears — first row should be our PURCHASE transaction
     await expect(page.getByText(`E2E Cement ${unique}`).first()).toBeVisible();
-    await expect(page.locator('span').filter({ hasText: /^IN$/ }).first()).toBeVisible();
+    await expect(page.locator('span').filter({ hasText: /^PURCHASE$/ }).first()).toBeVisible();
   });
 
   test('records an issue transaction', async ({ page }) => {
@@ -146,7 +146,7 @@ test.describe('golden path — purchase → issue → ledger balance', () => {
     await page.getByRole('button', { name: 'Record issue' }).click();
     await page.waitForURL(/\/inventory\/transactions/, { timeout: 15_000 });
 
-    await expect(page.locator('span').filter({ hasText: /^OUT$/ }).first()).toBeVisible();
+    await expect(page.locator('span').filter({ hasText: /^ISSUE$/ }).first()).toBeVisible();
   });
 
   test('item ledger shows running balance 100 − 30 = 70', async ({ page }) => {
@@ -162,7 +162,7 @@ test.describe('golden path — purchase → issue → ledger balance', () => {
     const currentStockSection = page.locator('text=Current stock').locator('..');
     await expect(currentStockSection).toContainText('70');
 
-    // The ledger body contains both IN (100) and OUT (30) rows, final balance 70
+    // The ledger body contains both PURCHASE (100) and ISSUE (30) rows, final balance 70
     const ledgerRows = page.locator('table.excel-grid tbody tr');
     await expect(ledgerRows).toHaveCount(2);
     // Final balance cell on the last row


### PR DESCRIPTION
Renamed 'IN/OUT' terminology to 'PURCHASE' and 'ISSUE' across the application UI to make it more intuitive for workers.
- Updated `TransactionsClient` to use 'PURCHASE'/'ISSUE' filter labels and badges.
- Updated `ItemLedgerClient` to use 'Purchase qty'/'Issue qty' headers and 'PURCHASE'/'ISSUE' types.
- Updated `DashboardPage` recent transactions to use 'PURCHASE'/'ISSUE'.
- Updated `EditDialog` to reflect purchase/issue terminology in titles and labels.
- Updated `ItemsReportClient` empty state description.
- Updated `golden-path.spec.ts` e2e test to assert on new labels.

Fixes #29

---
*PR created automatically by Jules for task [3144734172687257484](https://jules.google.com/task/3144734172687257484) started by @shubhambansal013*