### PR TITLE
Move conversion factor to purchase transactions

### DIFF
--- a/app/(app)/inventory/inward/new/inward-form.tsx
+++ b/app/(app)/inventory/inward/new/inward-form.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useTransition } from 'react';
+import { useState, useTransition, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -12,11 +12,13 @@ import { createPurchase } from './actions';
 type Site = { id: string; name: string; code: string };
 type Item = { id: string; name: string; code: string | null; stock_unit: string };
 type Party = { id: string; name: string; type: string };
+type Unit = { id: string; label: string; category: string | null };
 
 type Props = {
   sites: Site[];
   items: Item[];
   suppliers: Party[];
+  units: Unit[];
 };
 
 /**
@@ -25,7 +27,7 @@ type Props = {
  * HTML submit + useTransition to stream the server action and keep the
  * button in a "Saving…" state until the response lands.
  */
-export function PurchaseForm({ sites, items, suppliers }: Props) {
+export function PurchaseForm({ sites, items, suppliers, units }: Props) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
 
@@ -33,6 +35,8 @@ export function PurchaseForm({ sites, items, suppliers }: Props) {
   const [siteId, setSiteId] = useState<string | null>(sites[0]?.id ?? null);
   const [itemId, setItemId] = useState<string | null>(null);
   const [qty, setQty] = useState('');
+  const [receivedUnit, setReceivedUnit] = useState<string | null>(null);
+  const [convFactor, setConvFactor] = useState('1');
   const [supplierId, setSupplierId] = useState<string | null>(null);
   const [invoiceNo, setInvoiceNo] = useState('');
 
@@ -45,10 +49,18 @@ export function PurchaseForm({ sites, items, suppliers }: Props) {
 
   const selectedItem = items.find((i) => i.id === itemId);
 
+  // Sync receivedUnit when itemId changes
+  useEffect(() => {
+    if (selectedItem) {
+      setReceivedUnit(selectedItem.stock_unit);
+      setConvFactor('1');
+    }
+  }, [selectedItem]);
+
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!siteId || !itemId || !qty) {
-      toast.error('Please fill item, qty, and site.');
+    if (!siteId || !itemId || !qty || !receivedUnit || !convFactor) {
+      toast.error('Please fill all required fields.');
       return;
     }
     startTransition(async () => {
@@ -56,9 +68,9 @@ export function PurchaseForm({ sites, items, suppliers }: Props) {
         site_id: siteId,
         item_id: itemId,
         received_qty: qty,
-        received_unit: selectedItem?.stock_unit ?? '',
+        received_unit: receivedUnit,
         stock_unit: selectedItem?.stock_unit ?? '',
-        unit_conv_factor: 1,
+        unit_conv_factor: convFactor,
         vendor_id: supplierId ?? null,
         invoice_no: invoiceNo || null,
         rate: detailed && rate ? rate : null,
@@ -83,6 +95,15 @@ export function PurchaseForm({ sites, items, suppliers }: Props) {
     sub: i.code ? `${i.code} · ${i.stock_unit}` : i.stock_unit,
   }));
   const supplierOptions = suppliers.map((p) => ({ value: p.id, label: p.name }));
+  const unitOptions = units.map((u) => ({
+    value: u.id,
+    label: u.label,
+    group: u.category,
+  }));
+
+  const q = parseFloat(qty);
+  const f = parseFloat(convFactor);
+  const stockQty = !isNaN(q) && !isNaN(f) ? (q * f).toFixed(4).replace(/\.?0+$/, '') : '0';
 
   return (
     <form onSubmit={onSubmit} className="space-y-4">
@@ -106,9 +127,9 @@ export function PurchaseForm({ sites, items, suppliers }: Props) {
         />
       </div>
 
-      <div className="grid grid-cols-[1fr_100px] gap-3">
+      <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
-          <Label htmlFor="qty">Qty *</Label>
+          <Label htmlFor="qty">Received Qty *</Label>
           <Input
             id="qty"
             type="number"
@@ -121,13 +142,40 @@ export function PurchaseForm({ sites, items, suppliers }: Props) {
           />
         </div>
         <div className="space-y-1.5">
-          <Label>Unit</Label>
-          <Input
-            value={selectedItem?.stock_unit ?? ''}
-            readOnly
-            className="bg-muted font-mono text-sm"
-            tabIndex={-1}
+          <Label htmlFor="receivedUnit">Received Unit *</Label>
+          <SearchableSelect
+            options={unitOptions}
+            value={receivedUnit}
+            onChange={setReceivedUnit}
+            placeholder="Unit"
           />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="convFactor">Conv. Factor *</Label>
+          <Input
+            id="convFactor"
+            type="number"
+            inputMode="decimal"
+            step="any"
+            value={convFactor}
+            onChange={(e) => setConvFactor(e.target.value)}
+            className="font-mono tabular-nums"
+            required
+          />
+          <p className="text-muted-foreground text-[10px]">
+            {receivedUnit && selectedItem
+              ? `1 ${receivedUnit} = ${convFactor} ${selectedItem.stock_unit}`
+              : 'Stock units per received unit'}
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <Label>Stock Qty</Label>
+          <div className="bg-muted flex h-10 w-full items-center rounded-md border px-3 py-2 text-sm font-mono tabular-nums">
+            {stockQty} {selectedItem?.stock_unit}
+          </div>
         </div>
       </div>
 

--- a/app/(app)/inventory/inward/new/page.tsx
+++ b/app/(app)/inventory/inward/new/page.tsx
@@ -12,10 +12,11 @@ import { EmptyState } from '@/components/empty-state';
  */
 export default async function PurchaseNewPage() {
   const sb = await supabaseServer();
-  const [{ data: sites }, { data: items }, { data: parties }] = await Promise.all([
+  const [{ data: sites }, { data: items }, { data: parties }, { data: units }] = await Promise.all([
     sb.from('sites').select('id, name, code').order('name'),
     sb.from('items').select('id, name, code, stock_unit').order('code'),
     sb.from('parties').select('id, name, type').eq('type', 'SUPPLIER').order('name'),
+    sb.from('units').select('id, label, category').order('label'),
   ]);
 
   if (!sites || sites.length === 0) {
@@ -35,7 +36,12 @@ export default async function PurchaseNewPage() {
           Record goods received from a supplier. Fields marked * are required.
         </p>
       </header>
-      <PurchaseForm sites={sites} items={items ?? []} suppliers={parties ?? []} />
+      <PurchaseForm
+        sites={sites}
+        items={items ?? []}
+        suppliers={parties ?? []}
+        units={units ?? []}
+      />
     </div>
   );
 }

--- a/app/(app)/inventory/transactions/edit-dialog.tsx
+++ b/app/(app)/inventory/transactions/edit-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { SearchableSelect } from '@/components/searchable-select';
 import { editPurchase, editIssue } from './actions';
 
 export type EditTarget = {
@@ -19,10 +20,15 @@ export type EditTarget = {
   type: 'IN' | 'OUT';
   currentQty: number;
   currentRef: string;
+  receivedUnit?: string | null;
+  convFactor?: number | null;
 };
+
+type Unit = { id: string; label: string; category: string | null };
 
 type Props = {
   target: EditTarget | null;
+  units: Unit[];
   onOpenChange: (o: boolean) => void;
   onSuccess: () => void;
 };
@@ -35,12 +41,14 @@ type Props = {
  * and the audit trigger writes before/after JSONB into
  * `inventory_edit_log`.
  */
-export function EditDialog({ target, onOpenChange, onSuccess }: Props) {
+export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
   // Derive initial form state from the target. The dialog instance is
   // keyed on target.id by the parent (React re-mounts between targets),
   // so these useState hooks read the target at mount time — no effect
   // needed and no cascading re-renders.
   const [qty, setQty] = useState(target ? String(target.currentQty) : '');
+  const [receivedUnit, setReceivedUnit] = useState(target?.receivedUnit ?? '');
+  const [convFactor, setConvFactor] = useState(target ? String(target.convFactor) : '1');
   const [ref, setRef] = useState(target?.currentRef ?? '');
   const [reason, setReason] = useState('');
   const [pending, startTransition] = useTransition();
@@ -55,12 +63,16 @@ export function EditDialog({ target, onOpenChange, onSuccess }: Props) {
       // the server action's omitUndefined helper so we avoid blowing over
       // columns the user didn't touch.
       const qtyChanged = qty !== String(target.currentQty);
+      const unitChanged = isIn && receivedUnit !== target.receivedUnit;
+      const factorChanged = isIn && convFactor !== String(target.convFactor);
       const refChanged = ref !== target.currentRef;
       const payload = isIn
         ? {
             id: target.id,
             reason: reason.trim(),
             ...(qtyChanged ? { received_qty: qty } : {}),
+            ...(unitChanged ? { received_unit: receivedUnit } : {}),
+            ...(factorChanged ? { unit_conv_factor: convFactor } : {}),
             ...(refChanged ? { invoice_no: ref || null } : {}),
           }
         : {
@@ -91,18 +103,60 @@ export function EditDialog({ target, onOpenChange, onSuccess }: Props) {
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="space-y-1.5">
-            <Label htmlFor="edit-qty">Qty</Label>
-            <Input
-              id="edit-qty"
-              type="number"
-              inputMode="decimal"
-              step="any"
-              value={qty}
-              onChange={(e) => setQty(e.target.value)}
-              className="font-mono tabular-nums"
-            />
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-qty">{isIn ? 'Received Qty' : 'Qty'}</Label>
+              <Input
+                id="edit-qty"
+                type="number"
+                inputMode="decimal"
+                step="any"
+                value={qty}
+                onChange={(e) => setQty(e.target.value)}
+                className="font-mono tabular-nums"
+              />
+            </div>
+            {isIn && (
+              <div className="space-y-1.5">
+                <Label htmlFor="edit-unit">Received Unit</Label>
+                <SearchableSelect
+                  options={units.map((u) => ({
+                    value: u.id,
+                    label: u.label,
+                    group: u.category,
+                  }))}
+                  value={receivedUnit}
+                  onChange={setReceivedUnit}
+                  placeholder="Select unit"
+                />
+              </div>
+            )}
           </div>
+
+          {isIn && (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="edit-factor">Conv. Factor</Label>
+                <Input
+                  id="edit-factor"
+                  type="number"
+                  inputMode="decimal"
+                  step="any"
+                  value={convFactor}
+                  onChange={(e) => setConvFactor(e.target.value)}
+                  className="font-mono tabular-nums"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Stock Qty</Label>
+                <div className="bg-muted flex h-10 w-full items-center rounded-md border px-3 py-2 text-sm font-mono tabular-nums">
+                  {!isNaN(parseFloat(qty)) && !isNaN(parseFloat(convFactor))
+                    ? (parseFloat(qty) * parseFloat(convFactor)).toFixed(4).replace(/\.?0+$/, '')
+                    : '0'}
+                </div>
+              </div>
+            </div>
+          )}
 
           <div className="space-y-1.5">
             <Label htmlFor="edit-ref">{isIn ? 'Invoice #' : 'Issued to'}</Label>

--- a/app/(app)/inventory/transactions/edit-dialog.tsx
+++ b/app/(app)/inventory/transactions/edit-dialog.tsx
@@ -54,7 +54,7 @@ export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
   const [pending, startTransition] = useTransition();
 
   const canSubmit = reason.trim().length > 0 && !pending;
-  const isIn = target?.type === 'PURCHASE';
+  const isPurchase = target?.type === 'PURCHASE';
 
   const handle = () => {
     if (!target || !canSubmit) return;
@@ -63,10 +63,10 @@ export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
       // the server action's omitUndefined helper so we avoid blowing over
       // columns the user didn't touch.
       const qtyChanged = qty !== String(target.currentQty);
-      const unitChanged = isIn && receivedUnit !== target.receivedUnit;
-      const factorChanged = isIn && convFactor !== String(target.convFactor);
+      const unitChanged = isPurchase && receivedUnit !== target.receivedUnit;
+      const factorChanged = isPurchase && convFactor !== String(target.convFactor);
       const refChanged = ref !== target.currentRef;
-      const payload = isIn
+      const payload = isPurchase
         ? {
             id: target.id,
             reason: reason.trim(),
@@ -81,7 +81,7 @@ export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
             ...(qtyChanged ? { qty } : {}),
             ...(refChanged ? { issued_to_legacy: ref || null } : {}),
           };
-      const res = isIn ? await editPurchase(payload) : await editIssue(payload);
+      const res = isPurchase ? await editPurchase(payload) : await editIssue(payload);
       if (res.ok) {
         toast.success('Saved. Audit log captured the reason.');
         onSuccess();

--- a/app/(app)/inventory/transactions/edit-dialog.tsx
+++ b/app/(app)/inventory/transactions/edit-dialog.tsx
@@ -17,7 +17,7 @@ import { editPurchase, editIssue } from './actions';
 
 export type EditTarget = {
   id: string;
-  type: 'IN' | 'OUT';
+  type: 'PURCHASE' | 'ISSUE';
   currentQty: number;
   currentRef: string;
   receivedUnit?: string | null;
@@ -54,7 +54,7 @@ export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
   const [pending, startTransition] = useTransition();
 
   const canSubmit = reason.trim().length > 0 && !pending;
-  const isIn = target?.type === 'IN';
+  const isIn = target?.type === 'PURCHASE';
 
   const handle = () => {
     if (!target || !canSubmit) return;
@@ -95,17 +95,17 @@ export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
     <Dialog open={target !== null} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Edit {isIn ? 'purchase' : 'issue'} transaction</DialogTitle>
+          <DialogTitle>Edit {isPurchase ? 'purchase' : 'issue'} transaction</DialogTitle>
           <p className="text-muted-foreground text-sm">
-            Only qty and {isIn ? 'invoice #' : 'issued-to'} can be edited inline. For destination
-            changes, soft-delete and re-enter.
+            Only qty and {isPurchase ? 'invoice #' : 'issued-to'} can be edited inline. For
+            destination changes, soft-delete and re-enter.
           </p>
         </DialogHeader>
 
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="edit-qty">{isIn ? 'Received Qty' : 'Qty'}</Label>
+              <Label htmlFor="edit-qty">{isPurchase ? 'Received Qty' : 'Qty'}</Label>
               <Input
                 id="edit-qty"
                 type="number"
@@ -116,7 +116,7 @@ export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
                 className="font-mono tabular-nums"
               />
             </div>
-            {isIn && (
+            {isPurchase && (
               <div className="space-y-1.5">
                 <Label htmlFor="edit-unit">Received Unit</Label>
                 <SearchableSelect
@@ -133,7 +133,7 @@ export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
             )}
           </div>
 
-          {isIn && (
+          {isPurchase && (
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
                 <Label htmlFor="edit-factor">Conv. Factor</Label>
@@ -159,7 +159,7 @@ export function EditDialog({ target, units, onOpenChange, onSuccess }: Props) {
           )}
 
           <div className="space-y-1.5">
-            <Label htmlFor="edit-ref">{isIn ? 'Invoice #' : 'Issued to'}</Label>
+            <Label htmlFor="edit-ref">{isPurchase ? 'Invoice #' : 'Issued to'}</Label>
             <Input id="edit-ref" value={ref} onChange={(e) => setRef(e.target.value)} />
           </div>
 

--- a/app/(app)/inventory/transactions/page.tsx
+++ b/app/(app)/inventory/transactions/page.tsx
@@ -17,11 +17,11 @@ export const dynamic = 'force-dynamic';
 export default async function TransactionsPage() {
   const sb = await supabaseServer();
 
-  const [{ data: purchases }, { data: issues }] = await Promise.all([
+  const [{ data: purchases }, { data: issues }, { data: units }] = await Promise.all([
     sb
       .from('purchases')
       .select(
-        `id, site_id, item_id, received_qty, stock_qty, rate, total_amount, receipt_date, invoice_no,
+        `id, site_id, item_id, received_qty, received_unit, unit_conv_factor, stock_qty, rate, total_amount, receipt_date, invoice_no,
          item:items(id, code, name, stock_unit),
          vendor:parties(id, name)`,
       )
@@ -41,7 +41,14 @@ export default async function TransactionsPage() {
       .eq('is_deleted', false)
       .order('issue_date', { ascending: false })
       .limit(500),
+    sb.from('units').select('id, label, category').order('label'),
   ]);
 
-  return <TransactionsClient purchases={purchases ?? []} issues={issues ?? []} />;
+  return (
+    <TransactionsClient
+      purchases={purchases ?? []}
+      issues={issues ?? []}
+      units={units ?? []}
+    />
+  );
 }

--- a/app/(app)/inventory/transactions/transactions-client.tsx
+++ b/app/(app)/inventory/transactions/transactions-client.tsx
@@ -23,7 +23,7 @@ import { EditDialog, type EditTarget } from './edit-dialog';
  */
 type UnifiedRow = {
   id: string;
-  type: 'IN' | 'OUT';
+  type: 'PURCHASE' | 'ISSUE';
   date: string;
   itemId: string;
   itemCode: string;
@@ -74,14 +74,17 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
   const router = useRouter();
   const [, startTransition] = useTransition();
   const [search, setSearch] = useState('');
-  const [typeFilter, setTypeFilter] = useState<'ALL' | 'IN' | 'OUT'>('ALL');
-  const [deleteTarget, setDeleteTarget] = useState<{ id: string; type: 'IN' | 'OUT' } | null>(null);
+  const [typeFilter, setTypeFilter] = useState<'ALL' | 'PURCHASE' | 'ISSUE'>('ALL');
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: string;
+    type: 'PURCHASE' | 'ISSUE';
+  } | null>(null);
   const [editTarget, setEditTarget] = useState<EditTarget | null>(null);
 
   const rows = useMemo<UnifiedRow[]>(() => {
     const inRows: UnifiedRow[] = purchases.map((p) => ({
       id: p.id,
-      type: 'IN',
+      type: 'PURCHASE',
       date: p.receipt_date,
       itemId: p.item?.id ?? '',
       itemCode: p.item?.code ?? '',
@@ -100,7 +103,7 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
       const dest = i.location?.full_path ?? i.party?.name ?? (i.dest ? `→ ${i.dest.code}` : '—');
       return {
         id: i.id,
-        type: 'OUT',
+        type: 'ISSUE',
         date: i.issue_date,
         itemId: i.item?.id ?? '',
         itemCode: i.item?.code ?? '',
@@ -136,17 +139,18 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
       accessorKey: 'type',
       header: 'Type',
       cell: ({ getValue }) => {
-        const v = getValue() as 'IN' | 'OUT';
+        const v = getValue() as 'PURCHASE' | 'ISSUE';
+        const label = v === 'PURCHASE' ? 'IN' : 'OUT';
         return (
           <Badge
             variant="outline"
             className={
-              v === 'IN'
+              v === 'PURCHASE'
                 ? 'border-primary/50 text-primary bg-primary/5'
                 : 'border-emerald-500/50 bg-emerald-500/5 text-emerald-700'
             }
           >
-            {v}
+            {label}
           </Badge>
         );
       },
@@ -173,7 +177,12 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
       header: 'Qty',
       cell: ({ row }) => {
         const r = row.original;
-        if (r.type === 'IN' && r.receivedUnit && r.receivedQty != null && r.receivedUnit !== r.unit) {
+        if (
+          r.type === 'PURCHASE' &&
+          r.receivedUnit &&
+          r.receivedQty != null &&
+          r.receivedUnit !== r.unit
+        ) {
           return (
             <div className="flex flex-col items-end">
               <span className="tabular-nums font-medium">{r.qty}</span>
@@ -212,7 +221,8 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
               setEditTarget({
                 id: row.original.id,
                 type: row.original.type,
-                currentQty: row.original.type === 'IN' ? row.original.receivedQty! : row.original.qty,
+                currentQty:
+                  row.original.type === 'PURCHASE' ? row.original.receivedQty! : row.original.qty,
                 currentRef: row.original.ref,
                 receivedUnit: row.original.receivedUnit ?? null,
                 convFactor: row.original.convFactor ?? null,
@@ -270,7 +280,7 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
           className="max-w-xs"
         />
         <div className="flex gap-1 rounded-sm border p-0.5">
-          {(['ALL', 'IN', 'OUT'] as const).map((t) => (
+          {(['ALL', 'PURCHASE', 'ISSUE'] as const).map((t) => (
             <button
               key={t}
               type="button"
@@ -281,7 +291,7 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
                   : 'text-muted-foreground hover:bg-accent'
               }`}
             >
-              {t}
+              {t === 'PURCHASE' ? 'IN' : t === 'ISSUE' ? 'OUT' : 'ALL'}
             </button>
           ))}
         </div>
@@ -326,7 +336,7 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
         confirmLabel="Delete"
         onConfirm={async (reason) => {
           if (!deleteTarget || !reason) return;
-          const fn = deleteTarget.type === 'IN' ? softDeletePurchase : softDeleteIssue;
+          const fn = deleteTarget.type === 'PURCHASE' ? softDeletePurchase : softDeleteIssue;
           const res = await fn({ id: deleteTarget.id, reason });
           if (res.ok) {
             toast.success('Transaction deleted.');

--- a/app/(app)/inventory/transactions/transactions-client.tsx
+++ b/app/(app)/inventory/transactions/transactions-client.tsx
@@ -34,12 +34,17 @@ type UnifiedRow = {
   destination: string;
   ref: string; // invoice or issued-to
   amount: number | null;
+  receivedUnit?: string | null;
+  convFactor?: number | null;
+  receivedQty?: number; // Only for IN
 };
 
 type PurchaseRow = {
   id: string;
   receipt_date: string;
   received_qty: number;
+  received_unit: string;
+  unit_conv_factor: number;
   stock_qty: number | null;
   total_amount: number | null;
   invoice_no: string | null;
@@ -61,9 +66,11 @@ type IssueRow = {
   worker: { id: string; code: string; full_name: string } | null;
 };
 
-type Props = { purchases: PurchaseRow[]; issues: IssueRow[] };
+type Unit = { id: string; label: string; category: string | null };
 
-export function TransactionsClient({ purchases, issues }: Props) {
+type Props = { purchases: PurchaseRow[]; issues: IssueRow[]; units: Unit[] };
+
+export function TransactionsClient({ purchases, issues, units }: Props) {
   const router = useRouter();
   const [, startTransition] = useTransition();
   const [search, setSearch] = useState('');
@@ -79,12 +86,15 @@ export function TransactionsClient({ purchases, issues }: Props) {
       itemId: p.item?.id ?? '',
       itemCode: p.item?.code ?? '',
       itemName: p.item?.name ?? '—',
-      qty: p.received_qty,
+      qty: p.stock_qty ?? 0,
       unit: p.item?.stock_unit ?? '',
       party: p.vendor?.name ?? '',
       destination: p.vendor?.name ?? '',
       ref: p.invoice_no ?? '',
       amount: p.total_amount,
+      receivedUnit: p.received_unit,
+      convFactor: p.unit_conv_factor,
+      receivedQty: p.received_qty,
     }));
     const outRows: UnifiedRow[] = issues.map((i) => {
       const dest = i.location?.full_path ?? i.party?.name ?? (i.dest ? `→ ${i.dest.code}` : '—');
@@ -161,9 +171,20 @@ export function TransactionsClient({ purchases, issues }: Props) {
     {
       accessorKey: 'qty',
       header: 'Qty',
-      cell: ({ getValue }) => (
-        <span className="block text-right tabular-nums">{String(getValue() ?? '')}</span>
-      ),
+      cell: ({ row }) => {
+        const r = row.original;
+        if (r.type === 'IN' && r.receivedUnit && r.receivedQty != null && r.receivedUnit !== r.unit) {
+          return (
+            <div className="flex flex-col items-end">
+              <span className="tabular-nums font-medium">{r.qty}</span>
+              <span className="text-muted-foreground text-[10px]">
+                ({r.receivedQty} {r.receivedUnit})
+              </span>
+            </div>
+          );
+        }
+        return <span className="block text-right tabular-nums">{r.qty}</span>;
+      },
     },
     { accessorKey: 'unit', header: 'Unit' },
     { accessorKey: 'destination', header: 'Party / Location' },
@@ -191,8 +212,10 @@ export function TransactionsClient({ purchases, issues }: Props) {
               setEditTarget({
                 id: row.original.id,
                 type: row.original.type,
-                currentQty: row.original.qty,
+                currentQty: row.original.type === 'IN' ? row.original.receivedQty! : row.original.qty,
                 currentRef: row.original.ref,
+                receivedUnit: row.original.receivedUnit ?? null,
+                convFactor: row.original.convFactor ?? null,
               })
             }
             className="text-muted-foreground hover:text-foreground"
@@ -281,6 +304,7 @@ export function TransactionsClient({ purchases, issues }: Props) {
       <EditDialog
         key={editTarget?.id ?? 'none'}
         target={editTarget}
+        units={units}
         onOpenChange={(o) => {
           if (!o) setEditTarget(null);
         }}

--- a/app/(app)/inventory/transactions/transactions-client.tsx
+++ b/app/(app)/inventory/transactions/transactions-client.tsx
@@ -140,7 +140,6 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
       header: 'Type',
       cell: ({ getValue }) => {
         const v = getValue() as 'PURCHASE' | 'ISSUE';
-        const label = v === 'PURCHASE' ? 'IN' : 'OUT';
         return (
           <Badge
             variant="outline"
@@ -150,7 +149,7 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
                 : 'border-emerald-500/50 bg-emerald-500/5 text-emerald-700'
             }
           >
-            {label}
+            {v}
           </Badge>
         );
       },
@@ -291,7 +290,7 @@ export function TransactionsClient({ purchases, issues, units }: Props) {
                   : 'text-muted-foreground hover:bg-accent'
               }`}
             >
-              {t === 'PURCHASE' ? 'IN' : t === 'ISSUE' ? 'OUT' : 'ALL'}
+              {t}
             </button>
           ))}
         </div>

--- a/app/(app)/inventory/transactions/transactions-client.tsx
+++ b/app/(app)/inventory/transactions/transactions-client.tsx
@@ -18,7 +18,7 @@ import { EditDialog, type EditTarget } from './edit-dialog';
 
 /**
  * A unified row shape that both purchases and issues flatten into.
- * `type: 'IN'` reads amber for purchases, `'OUT'` reads green for issues
+ * `type: 'PURCHASE'` reads amber for purchases, `'ISSUE'` reads green for issues
  * (semantic use of accent vs. chart-3).
  */
 type UnifiedRow = {
@@ -36,7 +36,7 @@ type UnifiedRow = {
   amount: number | null;
   receivedUnit?: string | null;
   convFactor?: number | null;
-  receivedQty?: number; // Only for IN
+  receivedQty?: number; // Only for PURCHASE
 };
 
 type PurchaseRow = {

--- a/app/(app)/masters/items/item-form.tsx
+++ b/app/(app)/masters/items/item-form.tsx
@@ -76,7 +76,6 @@ export function ItemForm(props: Props) {
           name: props.item.name,
           code: props.item.code ?? '',
           stock_unit: props.item.stock_unit,
-          stock_conv_factor: props.item.stock_conv_factor,
           category_id: props.item.category_id,
           hsn_code: props.item.hsn_code ?? '',
           reorder_level: props.item.reorder_level ?? undefined,
@@ -86,7 +85,6 @@ export function ItemForm(props: Props) {
           name: '',
           code: '',
           stock_unit: '',
-          stock_conv_factor: 1,
           category_id: null,
           hsn_code: '',
           reorder_level: undefined,
@@ -169,33 +167,6 @@ export function ItemForm(props: Props) {
                 placeholder="Select stock unit"
               />
               <FormDescription>Unit you track stock in (e.g. meter, kg).</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name={'stock_conv_factor' as keyof (ItemCreate | ItemUpdate)}
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Conversion factor *</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  step="0.0001"
-                  min={0}
-                  placeholder="1"
-                  {...field}
-                  value={(field.value as number | string | undefined) ?? ''}
-                  onChange={(e) =>
-                    field.onChange(e.target.value === '' ? undefined : Number(e.target.value))
-                  }
-                />
-              </FormControl>
-              <FormDescription>
-                How many stock units per received unit. Default 1 when received = stock.
-              </FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/app/(app)/masters/items/items-client.tsx
+++ b/app/(app)/masters/items/items-client.tsx
@@ -23,7 +23,6 @@ type ExportRow = {
   name: string;
   category: string;
   stock_unit: string;
-  stock_conv_factor: number;
   reorder_level: number | null;
 };
 
@@ -67,14 +66,6 @@ export function ItemsClient({ items, categories, units }: Props) {
       header: 'Stock unit',
     },
     {
-      accessorKey: 'stock_conv_factor',
-      header: 'Conv factor',
-      cell: ({ getValue }) => {
-        const v = getValue();
-        return <span className="block text-right tabular-nums">{v != null ? String(v) : '—'}</span>;
-      },
-    },
-    {
       accessorKey: 'reorder_level',
       header: 'Reorder Level',
       cell: ({ getValue }) => {
@@ -89,7 +80,6 @@ export function ItemsClient({ items, categories, units }: Props) {
     { key: 'name', header: 'Name' },
     { key: 'category', header: 'Category' },
     { key: 'stock_unit', header: 'Stock unit' },
-    { key: 'stock_conv_factor', header: 'Conv factor', numFmt: '#,##0.####' },
     { key: 'reorder_level', header: 'Reorder Level', numFmt: '#,##0' },
   ];
 
@@ -98,7 +88,6 @@ export function ItemsClient({ items, categories, units }: Props) {
     name: row.name,
     category: row.category?.label ?? '',
     stock_unit: row.stock_unit,
-    stock_conv_factor: row.stock_conv_factor,
     reorder_level: row.reorder_level,
   }));
 

--- a/components/searchable-select.tsx
+++ b/components/searchable-select.tsx
@@ -17,7 +17,7 @@ export type SearchableOption<V extends string = string> = {
   value: V;
   label: string;
   sub?: string;
-  group?: string;
+  group?: string | null;
 };
 
 type Props<V extends string> = {

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -241,7 +241,6 @@ export type Database = {
           id: string;
           name: string;
           reorder_level: number | null;
-          stock_conv_factor: number;
           stock_unit: string;
         };
         Insert: {
@@ -252,7 +251,6 @@ export type Database = {
           id?: string;
           name: string;
           reorder_level?: number | null;
-          stock_conv_factor?: number;
           stock_unit: string;
         };
         Update: {
@@ -263,7 +261,6 @@ export type Database = {
           id?: string;
           name?: string;
           reorder_level?: number | null;
-          stock_conv_factor?: number;
           stock_unit?: string;
         };
         Relationships: [

--- a/lib/validators/item.ts
+++ b/lib/validators/item.ts
@@ -7,10 +7,6 @@ import { z } from 'zod';
  *   - `stock_unit` is the canonical unit stock is tracked in (e.g.
  *     "meter", "kg"). It replaces the old `unit` column and is always
  *     recorded in the item master, never re-declared per purchase.
- *   - `stock_conv_factor` is the default "stock units per received
- *     unit" multiplier used when inward rows do not override it
- *     (e.g. a 100m roll of wire = 100 stock units per received roll).
- *     Defaults to 1 when the received unit equals the stock unit.
  *   - `reorder_level` is nullable; unset means "no low-stock alert".
  *
  * Updates require a non-empty `reason` because the audit trigger on
@@ -27,18 +23,6 @@ const stockUnitSchema = z
       .max(16, 'Stock unit must be 16 characters or fewer'),
   );
 
-function hasAtMostFourDecimals(value: number): boolean {
-  // At most 4 decimal places. Guard against binary float noise by
-  // rounding the scaled value before comparing.
-  const scaled = Math.round(value * 10_000);
-  return Math.abs(scaled / 10_000 - value) < 1e-9;
-}
-
-const stockConvFactorSchema = z.coerce
-  .number({ message: 'Conversion factor must be a number' })
-  .refine((value) => value > 0, 'Conversion factor must be greater than zero')
-  .refine(hasAtMostFourDecimals, 'Conversion factor may have at most 4 decimal places');
-
 export const itemCreateSchema = z.object({
   name: z.string().min(1).max(120),
   code: z
@@ -48,7 +32,6 @@ export const itemCreateSchema = z.object({
     .regex(/^[A-Z0-9_-]+$/i, 'Code must be letters, digits, dash, or underscore'),
   category_id: z.string().nullable().optional(),
   stock_unit: stockUnitSchema,
-  stock_conv_factor: stockConvFactorSchema.default(1),
   hsn_code: z.string().max(20).nullable().optional(),
   reorder_level: z.coerce.number().nonnegative().nullable().optional(),
 });

--- a/lib/validators/purchase-edit.ts
+++ b/lib/validators/purchase-edit.ts
@@ -11,6 +11,8 @@ export const purchaseEditSchema = z.object({
   id: z.string().uuid(),
   reason: z.string().min(1, 'A reason is required for every edit'),
   received_qty: z.coerce.number().positive().optional(),
+  received_unit: z.string().min(1).optional(),
+  unit_conv_factor: z.coerce.number().positive().optional(),
   rate: z.coerce.number().nonnegative().nullable().optional(),
   invoice_no: z.string().max(40).nullable().optional(),
   remarks: z.string().max(500).nullable().optional(),

--- a/schema.sql
+++ b/schema.sql
@@ -133,10 +133,6 @@ CREATE UNIQUE INDEX parties_short_code_uk
 -- ITEMS MASTER
 -- code              = GEI_code (internal short code for fast entry)
 -- stock_unit        = canonical unit stock is tracked and issued in
--- stock_conv_factor = default "stock units per received unit" multiplier
---                     used when a purchase row does not override it
---                     (e.g. 100m of wire per received roll). Defaults
---                     to 1 when received unit equals stock unit.
 -- =============================================================================
 
 CREATE TABLE items (
@@ -145,7 +141,6 @@ CREATE TABLE items (
   code              TEXT UNIQUE,
   category_id       TEXT REFERENCES item_categories(id),
   stock_unit        TEXT NOT NULL REFERENCES units(id),
-  stock_conv_factor NUMERIC NOT NULL DEFAULT 1 CHECK (stock_conv_factor > 0),
   hsn_code          TEXT,
   created_at        TIMESTAMPTZ DEFAULT now()
 );

--- a/schema.sql
+++ b/schema.sql
@@ -504,7 +504,7 @@ SELECT
     - COALESCE(SUM(iss.qty), 0)       AS current_stock
 FROM purchases p
 JOIN items i ON i.id = p.item_id
-JOIN units u ON u.id = i.unit
+JOIN units u ON u.id = i.stock_unit
 LEFT JOIN issues iss
        ON iss.site_id   = p.site_id
       AND iss.item_id   = p.item_id

--- a/supabase/migrations/20260424000001_remove_item_conv_factor.sql
+++ b/supabase/migrations/20260424000001_remove_item_conv_factor.sql
@@ -1,0 +1,4 @@
+-- Move stock_conv_factor from items to purchases
+-- Removed from items table as conversion factor is now transaction-specific
+
+ALTER TABLE items DROP COLUMN IF EXISTS stock_conv_factor;

--- a/tests/app/item-validator.test.ts
+++ b/tests/app/item-validator.test.ts
@@ -2,16 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { itemCreateSchema, itemUpdateSchema } from '@/lib/validators/item';
 
 describe('itemCreateSchema', () => {
-  it('accepts a valid item with name, code, and stock_unit (defaults conv factor to 1)', () => {
+  it('accepts a valid item with name, code, and stock_unit', () => {
     const result = itemCreateSchema.safeParse({
       name: 'Portland Cement 53 Grade',
       code: 'CEM-53',
       stock_unit: 'MT',
     });
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.stock_conv_factor).toBe(1);
-    }
   });
 
   it('rejects a code that contains a space', () => {
@@ -61,72 +58,6 @@ describe('itemCreateSchema', () => {
     }
   });
 
-  it('accepts a positive stock_conv_factor (e.g. 100 metres per roll)', () => {
-    const result = itemCreateSchema.safeParse({
-      name: 'Electrical Wire',
-      code: 'WIRE-25',
-      stock_unit: 'M',
-      stock_conv_factor: 100,
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.stock_conv_factor).toBe(100);
-    }
-  });
-
-  it('coerces a string stock_conv_factor "2.5" to number 2.5', () => {
-    const result = itemCreateSchema.safeParse({
-      name: 'Paint',
-      code: 'PAINT',
-      stock_unit: 'L',
-      stock_conv_factor: '2.5',
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.stock_conv_factor).toBe(2.5);
-    }
-  });
-
-  it('rejects zero stock_conv_factor', () => {
-    const result = itemCreateSchema.safeParse({
-      name: 'Paint',
-      code: 'PAINT',
-      stock_unit: 'L',
-      stock_conv_factor: 0,
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects negative stock_conv_factor', () => {
-    const result = itemCreateSchema.safeParse({
-      name: 'Paint',
-      code: 'PAINT',
-      stock_unit: 'L',
-      stock_conv_factor: -1,
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects stock_conv_factor with more than 4 decimal places', () => {
-    const result = itemCreateSchema.safeParse({
-      name: 'Paint',
-      code: 'PAINT',
-      stock_unit: 'L',
-      stock_conv_factor: 1.23456,
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('accepts stock_conv_factor with exactly 4 decimal places', () => {
-    const result = itemCreateSchema.safeParse({
-      name: 'Paint',
-      code: 'PAINT',
-      stock_unit: 'L',
-      stock_conv_factor: 1.2345,
-    });
-    expect(result.success).toBe(true);
-  });
-
   it('coerces string reorder_level "10" to number 10', () => {
     const result = itemCreateSchema.safeParse({
       name: 'River Sand',
@@ -157,7 +88,6 @@ describe('itemUpdateSchema', () => {
     const result = itemUpdateSchema.safeParse({
       id: sampleId,
       stock_unit: 'KG',
-      stock_conv_factor: 1,
       reason: 'Correcting stock unit after catalog review',
     });
     expect(result.success).toBe(true);

--- a/tests/rls/audit-log.test.ts
+++ b/tests/rls/audit-log.test.ts
@@ -52,7 +52,7 @@ describe('inventory_edit_log — audit trigger + RLS', () => {
     siteId = site!.id;
     const { data: item } = await svc
       .from('items')
-      .insert({ code: itemCode, name: 'Audit Cement', unit: 'MT' })
+      .insert({ code: itemCode, name: 'Audit Cement', stock_unit: 'MT' })
       .select()
       .single();
     itemId = item!.id;

--- a/tests/rls/masters.test.ts
+++ b/tests/rls/masters.test.ts
@@ -9,7 +9,7 @@ describe('masters RLS', () => {
 
     const { error } = await viewer.from('items').insert({
       name: 'Forbidden',
-      unit: 'NOS',
+      stock_unit: 'NOS',
       code: 'RLS-FORBIDDEN-1',
     });
     expect(error).not.toBeNull();
@@ -23,7 +23,7 @@ describe('masters RLS', () => {
 
     const { error } = await admin.from('items').insert({
       name: 'Rebar 8mm',
-      unit: 'MT',
+      stock_unit: 'MT',
       code: 'RLS-ALLOW-1',
     });
     expect(error).toBeNull();
@@ -38,7 +38,7 @@ describe('masters RLS', () => {
     // Ensure at least one item exists
     await service()
       .from('items')
-      .upsert({ name: 'Anyone', unit: 'NOS', code: 'RLS-ANY-1' }, { onConflict: 'code' });
+      .upsert({ name: 'Anyone', stock_unit: 'NOS', code: 'RLS-ANY-1' }, { onConflict: 'code' });
 
     const { data, error } = await viewer.from('items').select('id, code').eq('code', 'RLS-ANY-1');
     expect(error).toBeNull();
@@ -60,7 +60,7 @@ describe('masters RLS', () => {
       .single();
     const { data: item } = await svc
       .from('items')
-      .upsert({ code: 'RLS-ITM-1', name: 'Test', unit: 'NOS' }, { onConflict: 'code' })
+      .upsert({ code: 'RLS-ITM-1', name: 'Test', stock_unit: 'NOS' }, { onConflict: 'code' })
       .select()
       .single();
     const { data: purchase } = await svc

--- a/tests/rls/role-matrix.test.ts
+++ b/tests/rls/role-matrix.test.ts
@@ -45,7 +45,7 @@ describe('role matrix — masters writes', () => {
 
     const res = await u
       .from('items')
-      .insert({ code: `I-${uniq}-${role}`, name: `RM ${role}`, unit: 'NOS' });
+      .insert({ code: `I-${uniq}-${role}`, name: `RM ${role}`, stock_unit: 'NOS' });
 
     if (allow) expect(res.error).toBeNull();
     else expect(res.error).not.toBeNull();
@@ -63,7 +63,7 @@ describe('role matrix — masters writes', () => {
 
     const res = await u
       .from('items')
-      .insert({ code: `I-${uniq}-SITE-ADMIN`, name: 'Site-admin insert', unit: 'NOS' });
+      .insert({ code: `I-${uniq}-SITE-ADMIN`, name: 'Site-admin insert', stock_unit: 'NOS' });
     expect(res.error).toBeNull();
   });
 
@@ -80,7 +80,7 @@ describe('role matrix — masters writes', () => {
 
     const res = await u
       .from('items')
-      .insert({ code: `I-${uniq}-SM`, name: 'SM denied', unit: 'NOS' });
+      .insert({ code: `I-${uniq}-SM`, name: 'SM denied', stock_unit: 'NOS' });
     expect(res.error).not.toBeNull();
   });
 });
@@ -100,7 +100,7 @@ describe('role matrix — transaction writes via can_user', () => {
     siteId = site!.id;
     const { data: item } = await svc
       .from('items')
-      .insert({ code: `I-${uniq}`, name: 'Txn matrix item', unit: 'NOS' })
+      .insert({ code: `I-${uniq}`, name: 'Txn matrix item', stock_unit: 'NOS' })
       .select()
       .single();
     itemId = item!.id;

--- a/tests/rls/signup-approval.test.ts
+++ b/tests/rls/signup-approval.test.ts
@@ -36,7 +36,7 @@ describe('signup approval — inactive profiles cannot read masters', () => {
     siteId = site!.id;
     const { data: item } = await svc
       .from('items')
-      .insert({ code: `I-${uniq}`, name: 'SA Item', unit: 'NOS' })
+      .insert({ code: `I-${uniq}`, name: 'SA Item', stock_unit: 'NOS' })
       .select()
       .single();
     itemId = item!.id;


### PR DESCRIPTION
This change moves the responsibility of unit conversion from the Item Master to individual Purchase transactions. This allows items (like wire) to be purchased in various units (like rolls or meters) with different conversion factors per transaction. It also enables users to correct mistakes in quantity or conversion factors after the transaction has been recorded, which was previously difficult due to soft-delete constraints.

Key changes:
1. Schema: Removed stock_conv_factor from 'items' table.
2. Item Master: Updated UI and validators to remove the default conversion factor.
3. Purchase Entry: Added received_unit and unit_conv_factor fields to the form.
4. Transaction Management: Updated the edit dialog to include conversion fields and the transaction list to provide better visibility into both received and stock quantities.

Fixes #28

---
*PR created automatically by Jules for task [2502501816823993323](https://jules.google.com/task/2502501816823993323) started by @shubhambansal013*