### PR TITLE
chore: fix GitHub CI environment variable mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
 
+env:
+  NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
 jobs:
   lint-typecheck-unit:
     runs-on: ubuntu-latest
@@ -32,9 +37,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Load env
         run: |
-          supabase status -o env | grep API_URL | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV
-          supabase status -o env | grep ANON_KEY | sed 's/ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
-          supabase status -o env | grep SERVICE_ROLE_KEY | sed 's/SERVICE_ROLE_KEY=/SUPABASE_SERVICE_ROLE_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
+          supabase status -o env | grep ^API_URL= | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV
+          supabase status -o env | grep ^ANON_KEY= | sed 's/ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
+          supabase status -o env | grep ^SERVICE_ROLE_KEY= | sed 's/SERVICE_ROLE_KEY=/SUPABASE_SERVICE_ROLE_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
       - run: pnpm test:rls
 
   e2e:
@@ -52,8 +57,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Load env
         run: |
-          supabase status -o env | grep API_URL | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV
-          supabase status -o env | grep ANON_KEY | sed 's/ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
-          supabase status -o env | grep SERVICE_ROLE_KEY | sed 's/SERVICE_ROLE_KEY=/SUPABASE_SERVICE_ROLE_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
+          supabase status -o env | grep ^API_URL= | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV
+          supabase status -o env | grep ^ANON_KEY= | sed 's/ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
+          supabase status -o env | grep ^SERVICE_ROLE_KEY= | sed 's/SERVICE_ROLE_KEY=/SUPABASE_SERVICE_ROLE_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm e2e


### PR DESCRIPTION
This change adds a global environment block to the GitHub CI workflow to correctly map GitHub secrets and variables. It also hardens the environment variable extraction logic in the 'rls' and 'e2e' jobs to ensure local Supabase credentials correctly override the global ones during tests.

Fixes #38

---
*PR created automatically by Jules for task [18124050335224129964](https://jules.google.com/task/18124050335224129964) started by @shubhambansal013*