### PR TITLE
Make left navigation pane scrollable

### DIFF
--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -206,12 +206,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           id="app-nav"
           aria-label="Primary"
           className={cn(
-            'print:hide bg-card shrink-0 border-r',
+            'print:hide bg-card shrink-0 border-r overflow-y-auto',
             // Mobile: fixed slide-in drawer.
             'fixed inset-y-0 left-0 z-40 w-64 transform transition-transform duration-200 ease-out',
             drawerOpen ? 'translate-x-0' : '-translate-x-full',
-            // Desktop: static 52-unit sidebar, no transform.
-            'md:static md:z-auto md:w-52 md:translate-x-0 md:transition-none',
+            // Desktop: sticky 52-unit sidebar, no transform.
+            'md:sticky md:top-12 md:h-[calc(100vh-3rem)] md:z-auto md:w-52 md:translate-x-0 md:transition-none',
           )}
         >
           <div className="flex h-12 items-center justify-between border-b px-3 md:hidden">


### PR DESCRIPTION
The left navigation pane was not scrollable, making bottom items unreachable on smaller screens or when the menu was long. This PR:
1. Adds `overflow-y-auto` to the `nav` element in `AppShell`.
2. Updates desktop styling from `md:static` to `md:sticky md:top-12 md:h-[calc(100vh-3rem)]` so the sidebar remains fixed and scrollable.
3. Verified via unit tests, linting, and manual code inspection.

Fixes #50

---
*PR created automatically by Jules for task [11064556532515300573](https://jules.google.com/task/11064556532515300573) started by @shubhambansal013*