### PR TITLE
Enforce CI checks before deployment while keeping workflows separate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 on:
   pull_request:
     branches: [main, staging]
-  push:
-    branches: [main, staging]
+  workflow_call:
 
 env:
   NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
   migrate:
+    needs: ci
     runs-on: ubuntu-latest
     name: Run Supabase Migrations
     environment: ${{ github.ref_name == 'main' && 'prod' || 'staging' }}
@@ -60,4 +65,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build and Deploy
-        run: pnpm run  ${{ github.ref_name == 'main' && 'deploy:prod' || 'deploy:staging' }}
+        run: pnpm run ${{ github.ref_name == 'main' && 'deploy:prod' || 'deploy:staging' }}


### PR DESCRIPTION
This change ensures that deployments to Supabase and Cloudflare only occur after all CI checks (linting, typechecking, unit tests, and database tests) have passed. It uses GitHub Actions reusable workflows to orchestrate the dependency between the `ci.yml` and `deploy.yml` files while maintaining them as separate entities.

Fixes #83

---
*PR created automatically by Jules for task [439993800837876670](https://jules.google.com/task/439993800837876670) started by @shubhambansal013*