### PR TITLE
Remove legacy 'Issued to' and rename Worker selection to 'Issue to'

### DIFF
--- a/app/(app)/inventory/transactions/__tests__/edit-dialog.test.tsx
+++ b/app/(app)/inventory/transactions/__tests__/edit-dialog.test.tsx
@@ -1,14 +1,24 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { EditDialog, type EditTarget } from '../edit-dialog';
+import * as actions from '../actions';
+import { toast } from 'sonner';
 
 // Mock the components that might use server-side stuff
 vi.mock('@/components/worker-picker', () => ({
-  WorkerPicker: () => <div data-testid="worker-picker">Worker Picker</div>,
+  WorkerPicker: ({ onChange, value }: any) => (
+    <div data-testid="worker-picker" onClick={() => onChange('w2')}>
+      Worker Picker: {value}
+    </div>
+  ),
 }));
 
 vi.mock('@/components/searchable-select', () => ({
-  SearchableSelect: () => <div data-testid="searchable-select">Searchable Select</div>,
+  SearchableSelect: ({ onChange, value }: any) => (
+    <div data-testid="searchable-select" onClick={() => onChange('BAGS')}>
+      Searchable Select: {value}
+    </div>
+  ),
 }));
 
 vi.mock('../actions', () => ({
@@ -16,15 +26,29 @@ vi.mock('../actions', () => ({
   editIssue: vi.fn(),
 }));
 
+// Mock sonner
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 const mockUnits = [
   { id: 'NOS', label: 'NOS', category: 'COUNT' },
+  { id: 'BAGS', label: 'BAGS', category: 'WEIGHT' },
 ];
 
 const mockWorkers = [
   { id: 'w1', code: 'W001', full_name: 'John Doe', current_site_id: 's1' },
+  { id: 'w2', code: 'W002', full_name: 'Jane Smith', current_site_id: 's1' },
 ];
 
 describe('EditDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders correctly for a purchase transaction', () => {
     const target: EditTarget = {
       id: 'p1',
@@ -74,7 +98,221 @@ describe('EditDialog', () => {
     expect(screen.getByText('Edit issue transaction')).toBeDefined();
     expect(screen.getByText('Issue to')).toBeDefined();
     expect(screen.queryByText('Invoice #')).toBeNull();
-    // Legacy label should be gone
-    expect(screen.queryByText('Issued to (Legacy)')).toBeNull();
+  });
+
+  it('calls editPurchase with updated fields', async () => {
+    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as any);
+    const target: EditTarget = {
+      id: 'p1',
+      type: 'PURCHASE',
+      currentQty: 10,
+      currentRef: 'INV-001',
+      receivedUnit: 'NOS',
+      convFactor: 1,
+      siteId: 's1',
+    };
+
+    const onSuccess = vi.fn();
+    render(
+      <EditDialog
+        target={target}
+        units={mockUnits}
+        workers={mockWorkers}
+        onOpenChange={() => {}}
+        onSuccess={onSuccess}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Received Qty'), { target: { value: '20' } });
+    fireEvent.change(screen.getByLabelText('Invoice #'), { target: { value: 'INV-002' } });
+    fireEvent.change(screen.getByLabelText('Conv. Factor'), { target: { value: '2' } });
+    fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'Updated all fields' } });
+
+    // Simulate unit change
+    fireEvent.click(screen.getByTestId('searchable-select'));
+
+    fireEvent.click(screen.getByText('Save with reason'));
+
+    await waitFor(() => {
+      expect(actions.editPurchase).toHaveBeenCalledWith({
+        id: 'p1',
+        reason: 'Updated all fields',
+        received_qty: '20',
+        received_unit: 'BAGS',
+        unit_conv_factor: '2',
+        invoice_no: 'INV-002',
+      });
+      expect(toast.success).toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('calls editIssue with updated fields', async () => {
+    vi.mocked(actions.editIssue).mockResolvedValue({ ok: true, data: {} } as any);
+    const target: EditTarget = {
+      id: 'is1',
+      type: 'ISSUE',
+      currentQty: 5,
+      currentRef: 'Old Worker',
+      workerId: 'w1',
+      siteId: 's1',
+    };
+
+    const onSuccess = vi.fn();
+    render(
+      <EditDialog
+        target={target}
+        units={mockUnits}
+        workers={mockWorkers}
+        onOpenChange={() => {}}
+        onSuccess={onSuccess}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Qty'), { target: { value: '7' } });
+    fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'Updated issue fields' } });
+
+    // Simulate worker change
+    fireEvent.click(screen.getByTestId('worker-picker'));
+
+    fireEvent.click(screen.getByText('Save with reason'));
+
+    await waitFor(() => {
+      expect(actions.editIssue).toHaveBeenCalledWith({
+        id: 'is1',
+        reason: 'Updated issue fields',
+        qty: '7',
+        worker_id: 'w2',
+      });
+      expect(toast.success).toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('handles editPurchase failure', async () => {
+    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: false, error: 'Database error' } as any);
+    const target: EditTarget = {
+      id: 'p1',
+      type: 'PURCHASE',
+      currentQty: 10,
+      currentRef: 'INV-001',
+      receivedUnit: 'NOS',
+      convFactor: 1,
+      siteId: 's1',
+    };
+
+    render(
+      <EditDialog
+        target={target}
+        units={mockUnits}
+        workers={mockWorkers}
+        onOpenChange={() => {}}
+        onSuccess={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'Test failure' } });
+    fireEvent.click(screen.getByText('Save with reason'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Database error');
+    });
+  });
+
+  it('handles editIssue exception', async () => {
+    vi.mocked(actions.editIssue).mockRejectedValue(new Error('Network error'));
+    const target: EditTarget = {
+      id: 'is1',
+      type: 'ISSUE',
+      currentQty: 5,
+      currentRef: 'Old Worker',
+      workerId: 'w1',
+      siteId: 's1',
+    };
+
+    render(
+      <EditDialog
+        target={target}
+        units={mockUnits}
+        workers={mockWorkers}
+        onOpenChange={() => {}}
+        onSuccess={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'Test exception' } });
+    fireEvent.click(screen.getByText('Save with reason'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to save changes.');
+    });
+  });
+
+  it('does not send unchanged fields in payload', async () => {
+    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as any);
+    const target: EditTarget = {
+      id: 'p1',
+      type: 'PURCHASE',
+      currentQty: 10,
+      currentRef: 'INV-001',
+      receivedUnit: 'NOS',
+      convFactor: 1,
+      siteId: 's1',
+    };
+
+    render(
+      <EditDialog
+        target={target}
+        units={mockUnits}
+        workers={mockWorkers}
+        onOpenChange={() => {}}
+        onSuccess={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'No changes' } });
+    fireEvent.click(screen.getByText('Save with reason'));
+
+    await waitFor(() => {
+      expect(actions.editPurchase).toHaveBeenCalledWith({
+        id: 'p1',
+        reason: 'No changes',
+      });
+    });
+  });
+
+  it('handles null ref for purchase', async () => {
+    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as any);
+    const target: EditTarget = {
+      id: 'p1',
+      type: 'PURCHASE',
+      currentQty: 10,
+      currentRef: 'INV-001',
+      receivedUnit: 'NOS',
+      convFactor: 1,
+      siteId: 's1',
+    };
+
+    render(
+      <EditDialog
+        target={target}
+        units={mockUnits}
+        workers={mockWorkers}
+        onOpenChange={() => {}}
+        onSuccess={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Invoice #'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText(/Reason/), { target: { value: 'Clear invoice' } });
+    fireEvent.click(screen.getByText('Save with reason'));
+
+    await waitFor(() => {
+      expect(actions.editPurchase).toHaveBeenCalledWith({
+        id: 'p1',
+        reason: 'Clear invoice',
+        invoice_no: null,
+      });
+    });
   });
 });

--- a/app/(app)/inventory/transactions/__tests__/edit-dialog.test.tsx
+++ b/app/(app)/inventory/transactions/__tests__/edit-dialog.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EditDialog, type EditTarget } from '../edit-dialog';
+
+// Mock the components that might use server-side stuff
+vi.mock('@/components/worker-picker', () => ({
+  WorkerPicker: () => <div data-testid="worker-picker">Worker Picker</div>,
+}));
+
+vi.mock('@/components/searchable-select', () => ({
+  SearchableSelect: () => <div data-testid="searchable-select">Searchable Select</div>,
+}));
+
+vi.mock('../actions', () => ({
+  editPurchase: vi.fn(),
+  editIssue: vi.fn(),
+}));
+
+const mockUnits = [
+  { id: 'NOS', label: 'NOS', category: 'COUNT' },
+];
+
+const mockWorkers = [
+  { id: 'w1', code: 'W001', full_name: 'John Doe', current_site_id: 's1' },
+];
+
+describe('EditDialog', () => {
+  it('renders correctly for a purchase transaction', () => {
+    const target: EditTarget = {
+      id: 'p1',
+      type: 'PURCHASE',
+      currentQty: 10,
+      currentRef: 'INV-001',
+      receivedUnit: 'NOS',
+      convFactor: 1,
+      siteId: 's1',
+    };
+
+    render(
+      <EditDialog
+        target={target}
+        units={mockUnits}
+        workers={mockWorkers}
+        onOpenChange={() => {}}
+        onSuccess={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Edit purchase transaction')).toBeDefined();
+    expect(screen.getByText('Invoice #')).toBeDefined();
+    expect(screen.queryByText('Issue to')).toBeNull();
+  });
+
+  it('renders correctly for an issue transaction', () => {
+    const target: EditTarget = {
+      id: 'is1',
+      type: 'ISSUE',
+      currentQty: 5,
+      currentRef: 'Old Worker',
+      workerId: 'w1',
+      siteId: 's1',
+    };
+
+    render(
+      <EditDialog
+        target={target}
+        units={mockUnits}
+        workers={mockWorkers}
+        onOpenChange={() => {}}
+        onSuccess={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Edit issue transaction')).toBeDefined();
+    expect(screen.getByText('Issue to')).toBeDefined();
+    expect(screen.queryByText('Invoice #')).toBeNull();
+    // Legacy label should be gone
+    expect(screen.queryByText('Issued to (Legacy)')).toBeNull();
+  });
+});

--- a/app/(app)/inventory/transactions/__tests__/edit-dialog.test.tsx
+++ b/app/(app)/inventory/transactions/__tests__/edit-dialog.test.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 
 // Mock the components that might use server-side stuff
 vi.mock('@/components/worker-picker', () => ({
-  WorkerPicker: ({ onChange, value }: any) => (
+  WorkerPicker: ({ onChange, value }: { onChange: (v: string) => void; value: string | null }) => (
     <div data-testid="worker-picker" onClick={() => onChange('w2')}>
       Worker Picker: {value}
     </div>
@@ -14,7 +14,7 @@ vi.mock('@/components/worker-picker', () => ({
 }));
 
 vi.mock('@/components/searchable-select', () => ({
-  SearchableSelect: ({ onChange, value }: any) => (
+  SearchableSelect: ({ onChange, value }: { onChange: (v: string) => void; value: string }) => (
     <div data-testid="searchable-select" onClick={() => onChange('BAGS')}>
       Searchable Select: {value}
     </div>
@@ -101,7 +101,7 @@ describe('EditDialog', () => {
   });
 
   it('calls editPurchase with updated fields', async () => {
-    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as any);
+    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as never);
     const target: EditTarget = {
       id: 'p1',
       type: 'PURCHASE',
@@ -148,7 +148,7 @@ describe('EditDialog', () => {
   });
 
   it('calls editIssue with updated fields', async () => {
-    vi.mocked(actions.editIssue).mockResolvedValue({ ok: true, data: {} } as any);
+    vi.mocked(actions.editIssue).mockResolvedValue({ ok: true, data: {} } as never);
     const target: EditTarget = {
       id: 'is1',
       type: 'ISSUE',
@@ -190,7 +190,7 @@ describe('EditDialog', () => {
   });
 
   it('handles editPurchase failure', async () => {
-    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: false, error: 'Database error' } as any);
+    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: false, error: 'Database error' } as never);
     const target: EditTarget = {
       id: 'p1',
       type: 'PURCHASE',
@@ -249,7 +249,7 @@ describe('EditDialog', () => {
   });
 
   it('does not send unchanged fields in payload', async () => {
-    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as any);
+    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as never);
     const target: EditTarget = {
       id: 'p1',
       type: 'PURCHASE',
@@ -282,7 +282,7 @@ describe('EditDialog', () => {
   });
 
   it('handles null ref for purchase', async () => {
-    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as any);
+    vi.mocked(actions.editPurchase).mockResolvedValue({ ok: true, data: {} } as never);
     const target: EditTarget = {
       id: 'p1',
       type: 'PURCHASE',

--- a/app/(app)/inventory/transactions/edit-dialog.tsx
+++ b/app/(app)/inventory/transactions/edit-dialog.tsx
@@ -110,7 +110,7 @@ export function EditDialog({ target, units, workers, onOpenChange, onSuccess }: 
         <DialogHeader>
           <DialogTitle>Edit {isPurchase ? 'purchase' : 'issue'} transaction</DialogTitle>
           <p className="text-muted-foreground text-sm">
-            Only qty and {isPurchase ? 'invoice #' : 'issued-to'} can be edited inline. For
+            Only qty and {isPurchase ? 'invoice #' : 'issue to'} can be edited inline. For
             destination changes, soft-delete and re-enter.
           </p>
         </DialogHeader>
@@ -173,7 +173,7 @@ export function EditDialog({ target, units, workers, onOpenChange, onSuccess }: 
 
           {!isPurchase && target?.siteId && (
             <div className="space-y-1.5">
-              <Label>Worker</Label>
+              <Label>Issue to</Label>
               <WorkerPicker
                 workers={workers}
                 siteId={target.siteId}
@@ -183,10 +183,12 @@ export function EditDialog({ target, units, workers, onOpenChange, onSuccess }: 
             </div>
           )}
 
-          <div className="space-y-1.5">
-            <Label htmlFor="edit-ref">{isPurchase ? 'Invoice #' : 'Issued to (Legacy)'}</Label>
-            <Input id="edit-ref" value={ref} onChange={(e) => setRef(e.target.value)} />
-          </div>
+          {isPurchase && (
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-ref">Invoice #</Label>
+              <Input id="edit-ref" value={ref} onChange={(e) => setRef(e.target.value)} />
+            </div>
+          )}
 
           <div className="space-y-1.5">
             <Label htmlFor="edit-reason">


### PR DESCRIPTION
Updated the transaction edit dialog to modernize worker selection. The 'Worker' field is now labeled 'Issue to', and the legacy free-text field has been removed for issues. Purchase transactions still retain the 'Invoice #' field. Relevant unit tests were added and passed.

Fixes #92

---
*PR created automatically by Jules for task [10696545584284461996](https://jules.google.com/task/10696545584284461996) started by @shubhambansal013*