### PR TITLE
Split DB Tests CI & Docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,9 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy
         run: pnpm build
 
-  database-tests:
+  database-pgtap:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        test-group: [db, rls]
-      fail-fast: false
-    name: Database Tests (${{ matrix.test-group }})
+    name: Database Tests (pgTAP)
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -96,11 +92,44 @@ jobs:
         with: { version: latest }
       - run: supabase start
       - run: pnpm install --frozen-lockfile
-      - name: Load env (RLS only)
-        if: matrix.test-group == 'rls'
+      - name: Run pgTAP tests
+        run: |
+          set -o pipefail
+          pnpm test:db | tee pgtap-output.txt
+      - name: Report pgTAP Summary
+        if: always()
+        run: |
+          echo "### pgTAP Test Results" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -n 20 pgtap-output.txt >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  database-rls:
+    runs-on: ubuntu-latest
+    name: Database Tests (RLS)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: 'pnpm' }
+      - uses: supabase/setup-cli@v1
+        with: { version: latest }
+      - run: supabase start
+      - run: pnpm install --frozen-lockfile
+      - name: Load env
         run: |
           supabase status -o env | grep ^API_URL= | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV
           supabase status -o env | grep ^ANON_KEY= | sed 's/ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
           supabase status -o env | grep ^SERVICE_ROLE_KEY= | sed 's/SERVICE_ROLE_KEY=/SUPABASE_SERVICE_ROLE_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
-      - name: Run tests
-        run: pnpm test:${{ matrix.test-group }}
+      - name: Run RLS Tests
+        run: |
+          set -o pipefail
+          NO_COLOR=1 pnpm test:rls | tee rls-output.txt
+      - name: Report RLS Test Summary
+        if: always()
+        run: |
+          echo "### RLS Policy Test Results" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -n 20 rls-output.txt >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ This file provides context and guidelines for AI agents working on the GEI proje
 - **Testing:**
   - `lib/**/*.test.ts`: Logic unit tests (Vitest).
   - `components/**/*.test.tsx`: Component tests (RTL + Vitest).
-  - `tests/rls/**/*.test.ts`: RLS policy tests (requires `supabase start`).
+  - `tests/rls/**/*.test.ts`: RLS policy tests (requires `supabase start`). Ensure full coverage of policies in `schema.sql`.
+  - `supabase/tests/*.sql`: Database logic tests (pgTAP).
   - `tests/e2e/**/*.spec.ts`: Playwright e2e tests.
 - **Linting & Types:** `pnpm lint` and `pnpm typecheck` must be clean.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,10 +58,29 @@ supabase status -o env | grep ^SERVICE_ROLE_KEY= | sed 's/SERVICE_ROLE_KEY=/SUPA
 
 ## Continuous Integration (CI)
 
-All tests are executed automatically on every Pull Request.
+All tests are executed automatically on every Pull Request via the following jobs:
 
-- `lint-typecheck-unit`: Checks code style, types, and runs Unit tests.
-- `database`: Starts a local Supabase instance and runs pgTAP and RLS tests.
+- `static-analysis`: Runs `pnpm lint` and `pnpm typecheck`.
+- `unit-tests`: Runs `pnpm test` (Vitest unit tests).
+- `coverage`: Runs `pnpm test --coverage` and reports unit test coverage.
+- `database-pgtap`: Starts Supabase and runs `pnpm test:db`.
+- `database-rls`: Starts Supabase and runs `pnpm test:rls`.
+
+## Maintaining Database Tests
+
+### pgTAP (SQL)
+
+- **When to add:** New triggers, functions, or complex constraints in `schema.sql`.
+- **Where:** `supabase/tests/*.sql`.
+- **How:** Follow the pattern in `00001_audit_log.sql`. Use `BEGIN;` ... `ROLLBACK;` to keep tests isolated and idempotent.
+- **Verification:** Run `pnpm test:db` locally.
+
+### RLS (Vitest)
+
+- **When to add:** New tables or updated RLS policies in `schema.sql`.
+- **Where:** `tests/rls/*.test.ts`.
+- **How:** Use the `asUser` and `setGlobalRole` helpers from `helpers.ts` to simulate different roles.
+- **Verification:** Run `pnpm test:rls` locally. Ensure that all new policies in `schema.sql` are exercised by at least one test case to maintain "human-verified" coverage.
 
 ## Quality Gates
 


### PR DESCRIPTION
This PR improves the database testing pipeline by splitting pgTAP and RLS tests into separate CI jobs. This provides granular pass/fail feedback and allows for specific summary reporting for each suite. 

Additionally, it adds comprehensive documentation in `docs/testing.md` and `AGENTS.md` to guide agents and maintainers on when and how to add or update database tests. 

Key changes:
- `.github/workflows/ci.yml`: Replaced matrix `database-tests` with explicit `database-pgtap` and `database-rls` jobs.
- `docs/testing.md`: Added "Maintaining Database Tests" section with practical examples and CI job descriptions.
- `AGENTS.md`: Added pgTAP to the testing checklist and clarified RLS policy coverage expectations.
- Removed experimental and non-functional RLS coverage tracking (Vitest V8 cannot track SQL execution).

Fixes #91

---
*PR created automatically by Jules for task [16362505105458291705](https://jules.google.com/task/16362505105458291705) started by @shubhambansal013*