### PR TITLE
Standardize master record UI to right-side sliders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This file provides context and guidelines for AI agents working on the GEI proje
 - **Soft Delete Only:** `is_deleted` flags are used. Hard DELETEs are blocked by policy.
 - **Multi-site:** Every query and mutation must be scoped by `site_id`.
 - **Modular Code:** Reuse components like `SearchableSelect`, `DataGrid`, `PermissionGate`, `ExportButton`, `PrintButton`.
+- **Consistent UX:** Master record creation and editing should use right-side sliders (`Sheet`) instead of popups/dialogs for a consistent user experience.
 
 ## 3. Technical Guidelines
 - **Tailwind CSS v4:** Theme tokens in `app/globals.css`. No `tailwind.config.ts`.

--- a/app/(app)/masters/items/items-client.tsx
+++ b/app/(app)/masters/items/items-client.tsx
@@ -6,7 +6,7 @@ import { MasterShell } from '@/components/master-shell';
 import { DataGrid } from '@/components/data-grid';
 import { EmptyState } from '@/components/empty-state';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { ItemForm } from './item-form';
 import type { Database } from '@/lib/supabase/types';
 
@@ -34,7 +34,7 @@ type Props = {
 
 export function ItemsClient({ items, categories, units }: Props) {
   const [search, setSearch] = useState('');
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<ItemWithCategory | null>(null);
 
   const filtered = useMemo(() => {
@@ -93,11 +93,11 @@ export function ItemsClient({ items, categories, units }: Props) {
 
   const openCreate = () => {
     setEditing(null);
-    setDialogOpen(true);
+    setSheetOpen(true);
   };
 
   const handleSuccess = () => {
-    setDialogOpen(false);
+    setSheetOpen(false);
     setEditing(null);
   };
 
@@ -112,7 +112,7 @@ export function ItemsClient({ items, categories, units }: Props) {
     const item = filtered[rowIndex];
     if (item) {
       setEditing(item);
-      setDialogOpen(true);
+      setSheetOpen(true);
     }
   };
 
@@ -153,35 +153,37 @@ export function ItemsClient({ items, categories, units }: Props) {
         )}
       </MasterShell>
 
-      <Dialog
-        open={dialogOpen}
+      <Sheet
+        open={sheetOpen}
         onOpenChange={(open) => {
-          setDialogOpen(open);
+          setSheetOpen(open);
           if (!open) setEditing(null);
         }}
       >
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{editing ? 'Edit item' : 'New item'}</DialogTitle>
-          </DialogHeader>
-          {editing ? (
-            <ItemForm
-              mode="edit"
-              item={editing}
-              categories={categories}
-              units={units}
-              onSuccess={handleSuccess}
-            />
-          ) : (
-            <ItemForm
-              mode="create"
-              categories={categories}
-              units={units}
-              onSuccess={handleSuccess}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+        <SheetContent side="right" className="w-full overflow-y-auto p-6 sm:max-w-md">
+          <SheetHeader>
+            <SheetTitle>{editing ? 'Edit item' : 'New item'}</SheetTitle>
+          </SheetHeader>
+          <div className="mt-4">
+            {editing ? (
+              <ItemForm
+                mode="edit"
+                item={editing}
+                categories={categories}
+                units={units}
+                onSuccess={handleSuccess}
+              />
+            ) : (
+              <ItemForm
+                mode="create"
+                categories={categories}
+                units={units}
+                onSuccess={handleSuccess}
+              />
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/app/(app)/masters/units/units-client.tsx
+++ b/app/(app)/masters/units/units-client.tsx
@@ -8,7 +8,7 @@ import { MasterShell } from '@/components/master-shell';
 import { DataGrid } from '@/components/data-grid';
 import { EmptyState } from '@/components/empty-state';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { ConfirmDialog } from '@/components/confirm-dialog';
 import { UnitForm } from './unit-form';
 import { deleteUnit } from './actions';
@@ -36,7 +36,7 @@ type Props = {
 export function UnitsClient({ units }: Props) {
   const router = useRouter();
   const [search, setSearch] = useState('');
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<UnitRow | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<UnitRow | null>(null);
 
@@ -87,11 +87,11 @@ export function UnitsClient({ units }: Props) {
 
   const openCreate = () => {
     setEditing(null);
-    setDialogOpen(true);
+    setSheetOpen(true);
   };
 
   const handleSuccess = () => {
-    setDialogOpen(false);
+    setSheetOpen(false);
     setEditing(null);
   };
 
@@ -105,7 +105,7 @@ export function UnitsClient({ units }: Props) {
     const unit = filtered[rowIndex];
     if (unit) {
       setEditing(unit);
-      setDialogOpen(true);
+      setSheetOpen(true);
     }
   };
 
@@ -160,32 +160,34 @@ export function UnitsClient({ units }: Props) {
         )}
       </MasterShell>
 
-      <Dialog
-        open={dialogOpen}
+      <Sheet
+        open={sheetOpen}
         onOpenChange={(open) => {
-          setDialogOpen(open);
+          setSheetOpen(open);
           if (!open) setEditing(null);
         }}
       >
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{editing ? 'Edit unit' : 'New unit'}</DialogTitle>
-          </DialogHeader>
-          {editing ? (
-            <UnitForm
-              mode="edit"
-              unit={editing}
-              onSuccess={handleSuccess}
-              onRequestDelete={() => {
-                setDeleteTarget(editing);
-                setDialogOpen(false);
-              }}
-            />
-          ) : (
-            <UnitForm mode="create" onSuccess={handleSuccess} />
-          )}
-        </DialogContent>
-      </Dialog>
+        <SheetContent side="right" className="w-full overflow-y-auto p-6 sm:max-w-md">
+          <SheetHeader>
+            <SheetTitle>{editing ? 'Edit unit' : 'New unit'}</SheetTitle>
+          </SheetHeader>
+          <div className="mt-4">
+            {editing ? (
+              <UnitForm
+                mode="edit"
+                unit={editing}
+                onSuccess={handleSuccess}
+                onRequestDelete={() => {
+                  setDeleteTarget(editing);
+                  setSheetOpen(false);
+                }}
+              />
+            ) : (
+              <UnitForm mode="create" onSuccess={handleSuccess} />
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
 
       <ConfirmDialog
         open={deleteTarget !== null}


### PR DESCRIPTION
This PR standardizes the user interface for creating and editing master records. Previously, Items and Units used centered popups (Dialogs), while Parties and Sites used right-side sliders (Sheets). 

Changes:
- Modified `app/(app)/masters/items/items-client.tsx` to use `Sheet`.
- Modified `app/(app)/masters/units/units-client.tsx` to use `Sheet`.
- Updated `AGENTS.md` to include a new guideline for consistent UX, mandating the use of right-side sliders for master records.

This ensures a more uniform experience across the administrative sections of the application.

Fixes #95

---
*PR created automatically by Jules for task [9360333377095660283](https://jules.google.com/task/9360333377095660283) started by @shubhambansal013*