### PR TITLE
Make application name and description parametric

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,6 +2,9 @@ NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<from `supabase start` output (publishable key)>
 SUPABASE_SERVICE_ROLE_KEY=<from `supabase start` output (secret key)>
 
+NEXT_PUBLIC_APP_NAME=GEI
+NEXT_PUBLIC_APP_DESCRIPTION="Multi-site construction inventory management for GEI."
+
 # Google OAuth — create an OAuth client at https://console.cloud.google.com/
 # Set authorized redirect URI to http://127.0.0.1:54321/auth/v1/callback for local
 # and to https://<project-ref>.supabase.co/auth/v1/callback for production.

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
+import { APP_NAME } from '@/lib/constants';
 import { supabaseBrowser } from '@/lib/supabase/browser';
 
 /**
@@ -62,7 +63,7 @@ export default function LoginPage() {
       <div className="bg-card w-full max-w-[420px] rounded-md border p-8 shadow-sm">
         {/* Brand lockup — monospace wordmark doing double duty as a logo. */}
         <div className="mb-8 flex items-baseline gap-2">
-          <span className="text-primary font-mono text-2xl font-bold tracking-tight">GEI</span>
+          <span className="text-primary font-mono text-2xl font-bold tracking-tight">{APP_NAME}</span>
         </div>
 
         <h1 className="mb-1 text-lg font-semibold">Sign in</h1>
@@ -146,7 +147,7 @@ export default function LoginPage() {
         )}
       </div>
 
-      <p className="text-muted-foreground mt-6 text-xs">GEI · multi-site, role-scoped, audited</p>
+      <p className="text-muted-foreground mt-6 text-xs">{APP_NAME} · multi-site, role-scoped, audited</p>
     </main>
   );
 }

--- a/app/(auth)/pending/page.tsx
+++ b/app/(auth)/pending/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { supabaseBrowser } from '@/lib/supabase/browser';
 import { Button } from '@/components/ui/button';
+import { APP_NAME } from '@/lib/constants';
 
 /**
  * Shown to any signed-in user whose profile is `is_active=false`.
@@ -22,7 +23,7 @@ export default function PendingPage() {
     <main className="bg-muted/30 grid min-h-screen place-items-center p-6">
       <div className="bg-card w-full max-w-[420px] rounded-md border p-8 text-center shadow-sm">
         <div className="mb-6 flex items-baseline justify-center gap-2">
-          <span className="text-primary font-mono text-2xl font-bold tracking-tight">GEI</span>
+          <span className="text-primary font-mono text-2xl font-bold tracking-tight">{APP_NAME}</span>
           <span className="text-muted-foreground text-sm font-medium">inventory</span>
         </div>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
+import { APP_DESCRIPTION, APP_NAME } from '@/lib/constants';
 import './globals.css';
 
 const geistSans = Geist({
@@ -16,10 +17,10 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: 'GEI',
-    template: '%s — GEI',
+    default: APP_NAME,
+    template: `%s — ${APP_NAME}`,
   },
-  description: 'Multi-site construction inventory management for GEI.',
+  description: APP_DESCRIPTION,
 };
 
 export default function RootLayout({

--- a/components/__tests__/app-shell.test.tsx
+++ b/components/__tests__/app-shell.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AppShell } from '../app-shell';
 import { usePathname } from 'next/navigation';
+import { APP_NAME } from '@/lib/constants';
 import { useSiteStore } from '@/lib/stores/site';
 import { createCan } from '@/lib/permissions/can';
 import { supabaseBrowser } from '@/lib/supabase/browser';
@@ -99,6 +100,8 @@ describe('AppShell Navigation', () => {
     render(<AppShell>Content</AppShell>);
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText(APP_NAME)).toBeInTheDocument();
+    expect(screen.getByLabelText(`${APP_NAME} home`)).toBeInTheDocument();
   });
 
   it('hides admin-only items for non-admins', async () => {

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SiteSwitcher } from './site-switcher';
 import { Button } from '@/components/ui/button';
+import { APP_NAME } from '@/lib/constants';
 import { supabaseBrowser } from '@/lib/supabase/browser';
 import { createCan } from '@/lib/permissions/can';
 import { useSiteStore } from '@/lib/stores/site';
@@ -228,8 +229,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           >
             <Menu className="h-5 w-5" aria-hidden />
           </Button>
-          <Link href="/dashboard" aria-label="GEI home" className="flex items-baseline gap-1.5">
-            <span className="text-primary font-mono text-base font-bold tracking-tight">GEI</span>
+          <Link href="/dashboard" aria-label={`${APP_NAME} home`} className="flex items-baseline gap-1.5">
+            <span className="text-primary font-mono text-base font-bold tracking-tight">{APP_NAME}</span>
           </Link>
           <SiteSwitcher />
         </div>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,4 @@
+export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME || 'GEI';
+export const APP_DESCRIPTION =
+  process.env.NEXT_PUBLIC_APP_DESCRIPTION ||
+  `Multi-site construction inventory management for ${APP_NAME}.`;


### PR DESCRIPTION
The application name and description are now parametric, allowing for easy white-labeling or rebranding via environment variables.

Key changes:
1. **Centralized Constants**: Created `lib/constants.ts` which exports `APP_NAME` and `APP_DESCRIPTION` using `NEXT_PUBLIC_APP_NAME` and `NEXT_PUBLIC_APP_DESCRIPTION` respectively. It provides a fallback to "GEI" for backwards compatibility.
2. **UI Updates**: All user-facing instances of "GEI" in the main shell, login page, and pending page now use the `APP_NAME` constant.
3. **Metadata**: The root layout's metadata (title and description) now dynamically uses the configured values.
4. **Environment Configuration**: Added the new variables to `.env.local.example` for better discoverability.
5. **Testing**: Updated `app-shell.test.tsx` to ensure the UI correctly renders the configured app name.

Verification:
- All 111 unit tests passed.
- Frontend verification confirmed that setting `NEXT_PUBLIC_APP_NAME="Custom Inventory"` correctly updates the UI across multiple pages.

Fixes #99

---
*PR created automatically by Jules for task [9584768170288142622](https://jules.google.com/task/9584768170288142622) started by @shubhambansal013*