### PR TITLE
Reorder and rename columns in Transactions page

### DIFF
--- a/app/(app)/inventory/transactions/__tests__/transactions-client.test.tsx
+++ b/app/(app)/inventory/transactions/__tests__/transactions-client.test.tsx
@@ -78,15 +78,15 @@ describe('TransactionsClient', () => {
     // Verify headers
     expect(screen.getByText('Date')).toBeDefined();
     expect(screen.getByText('Type')).toBeDefined();
-    expect(screen.getByText('Code')).toBeDefined();
+    expect(screen.getByText('Item')).toBeDefined();
     expect(screen.getByText('Qty')).toBeDefined();
     expect(screen.getByText('Unit')).toBeDefined();
     expect(screen.getByText('Party')).toBeDefined();
     expect(screen.getByText('Location')).toBeDefined();
-    expect(screen.getByText('Ref')).toBeDefined();
+    expect(screen.getByText('Issue to')).toBeDefined();
 
-    // Verify "Item" (name) and "Amount" headers are NOT present
-    expect(screen.queryByText('Item')).toBeNull();
+    // Verify old "Code" and "Amount" headers are NOT present
+    expect(screen.queryByText('Code')).toBeNull();
     expect(screen.queryByText('Amount (₹)')).toBeNull();
 
     // Verify data

--- a/app/(app)/inventory/transactions/transactions-client.tsx
+++ b/app/(app)/inventory/transactions/transactions-client.tsx
@@ -146,6 +146,19 @@ export function TransactionsClient({ purchases, issues, units, workers }: Props)
   const columns: ColumnDef<UnifiedRow, unknown>[] = [
     { accessorKey: 'date', header: 'Date' },
     {
+      accessorKey: 'itemCode',
+      header: 'Item',
+      cell: ({ row }) => (
+        <Link
+          href={`/inventory/item/${row.original.itemId}`}
+          className="font-mono text-xs text-foreground hover:text-primary underline-offset-2 hover:underline"
+        >
+          {String(row.original.itemCode ?? '')}
+        </Link>
+      ),
+    },
+    { accessorKey: 'location', header: 'Location' },
+    {
       accessorKey: 'type',
       header: 'Type',
       cell: ({ getValue }) => {
@@ -163,18 +176,6 @@ export function TransactionsClient({ purchases, issues, units, workers }: Props)
           </Badge>
         );
       },
-    },
-    {
-      accessorKey: 'itemCode',
-      header: 'Code',
-      cell: ({ row }) => (
-        <Link
-          href={`/inventory/item/${row.original.itemId}`}
-          className="font-mono text-xs text-foreground hover:text-primary underline-offset-2 hover:underline"
-        >
-          {String(row.original.itemCode ?? '')}
-        </Link>
-      ),
     },
     {
       accessorKey: 'qty',
@@ -201,10 +202,9 @@ export function TransactionsClient({ purchases, issues, units, workers }: Props)
     },
     { accessorKey: 'unit', header: 'Unit' },
     { accessorKey: 'party', header: 'Party' },
-    { accessorKey: 'location', header: 'Location' },
     {
       accessorKey: 'ref',
-      header: 'Ref',
+      header: 'Issue to',
       cell: ({ row }) => {
         const r = row.original;
         if (r.type === 'PURCHASE') return r.ref;
@@ -258,13 +258,13 @@ export function TransactionsClient({ purchases, issues, units, workers }: Props)
 
   const exportCols: { key: keyof UnifiedRow; header: string; numFmt?: string }[] = [
     { key: 'date', header: 'Date' },
+    { key: 'itemCode', header: 'Item' },
+    { key: 'location', header: 'Location' },
     { key: 'type', header: 'Type' },
-    { key: 'itemCode', header: 'Code' },
     { key: 'qty', header: 'Qty', numFmt: '#,##0.00' },
     { key: 'unit', header: 'Unit' },
     { key: 'party', header: 'Party' },
-    { key: 'location', header: 'Location' },
-    { key: 'ref', header: 'Ref' },
+    { key: 'ref', header: 'Issue to' },
   ];
 
   return (


### PR DESCRIPTION
Reordered and renamed columns in the Transactions page to match the requested layout. 

Changes:
- Renamed 'Code' header to 'Item'.
- Renamed 'Ref' header to 'Issue to'.
- Reordered the `columns` array in `TransactionsClient` to the sequence: Date, Item, Location, Type, Qty, Unit, Party, Issue to.
- Synced `exportCols` with the new UI structure.
- Updated `transactions-client.test.tsx` to verify the new headers and ensure no regressions.

Fixes #101

---
*PR created automatically by Jules for task [7261415159522615825](https://jules.google.com/task/7261415159522615825) started by @shubhambansal013*