### PR TITLE
Speed up Playwright tests by parallelizing setup steps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,14 @@ jobs:
         with: { node-version: 20, cache: 'pnpm' }
       - uses: supabase/setup-cli@v1
         with: { version: latest }
-      - run: supabase start
-      - run: pnpm install --frozen-lockfile
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
+      - name: Parallel Setup
+        run: |
+          supabase start &
+          SUPABASE_PID=$!
+          (pnpm install --frozen-lockfile && pnpm exec playwright install --with-deps) &
+          INSTALL_PID=$!
+          wait $SUPABASE_PID || exit 1
+          wait $INSTALL_PID || exit 1
       - name: Load local Supabase env
         run: |
           supabase status -o env | grep ^API_URL= | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV


### PR DESCRIPTION
This change parallelizes the setup steps in the Playwright test job of the CI workflow. Previously, starting the Supabase local environment and installing Playwright browsers were sequential. By backgrounding the Supabase startup and combining it with the `pnpm install` and `playwright install` steps, we reduce the total time spent in setup.

Key changes:
- Consolidated setup steps into a "Parallel Setup" block.
- Ran `supabase start` in the background.
- Ran `pnpm install` and `playwright install` in the background (ensuring pnpm finishes before playwright).
- Added `wait` commands to ensure all background processes finish successfully before environment loading and test execution.

Fixes #106

---
*PR created automatically by Jules for task [12567707100674004238](https://jules.google.com/task/12567707100674004238) started by @shubhambansal013*