### PR TITLE
Optimize CI and Playwright Setup Speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,54 +78,57 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy
         run: pnpm build
-
-  database-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        test-group: [db, rls]
-      fail-fast: false
-    name: Database Tests (${{ matrix.test-group }})
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with: { version: 9 }
-      - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: 'pnpm' }
-      - uses: supabase/setup-cli@v1
-        with: { version: latest }
-      - run: supabase start
-      - run: pnpm install --frozen-lockfile
-      - name: Load env (RLS only)
-        if: matrix.test-group == 'rls'
-        run: |
-          supabase status -o env | grep ^API_URL= | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV
-          supabase status -o env | grep ^ANON_KEY= | sed 's/ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
-          supabase status -o env | grep ^SERVICE_ROLE_KEY= | sed 's/SERVICE_ROLE_KEY=/SUPABASE_SERVICE_ROLE_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
-      - name: Run tests
-        run: pnpm test:${{ matrix.test-group }}
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            .next
+            public
+            package.json
+            pnpm-lock.yaml
+            next.config.ts
 
   playwright-tests:
     runs-on: ubuntu-latest
-    needs: [build, database-tests]
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with: { version: 9 }
       - uses: actions/setup-node@v4
         with: { node-version: 20, cache: 'pnpm' }
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - uses: supabase/setup-cli@v1
         with: { version: latest }
-      - run: supabase start
-      - run: pnpm install --frozen-lockfile
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
+      - name: Parallel Setup (Supabase & Playwright)
+        run: |
+          supabase start &
+          (pnpm install --frozen-lockfile && [ "${{ steps.playwright-cache.outputs.cache-hit }}" != "true" ] && pnpm exec playwright install --with-deps || pnpm exec playwright install-deps) &
+          wait
       - name: Load local Supabase env
         run: |
           supabase status -o env | grep ^API_URL= | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV
           supabase status -o env | grep ^ANON_KEY= | sed 's/ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
           supabase status -o env | grep ^SERVICE_ROLE_KEY= | sed 's/SERVICE_ROLE_KEY=/SUPABASE_SERVICE_ROLE_KEY=/' | sed 's/"//g' >> $GITHUB_ENV
+      - name: Run Database tests
+        run: pnpm test:db
+      - name: Run RLS tests
+        run: pnpm test:rls
       - name: Run Playwright tests
+        env:
+          PLAYWRIGHT_WEBSERVER_COMMAND: pnpm start
         run: pnpm test:e2e
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-output
-          path: |
-            .next
-            public
-            package.json
-            pnpm-lock.yaml
-            next.config.ts
+          path: .next
 
   playwright-tests:
     runs-on: ubuntu-latest
@@ -102,6 +97,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-output
+          path: .next
       - name: Cache Playwright Browsers
         uses: actions/cache@v4
         id: playwright-cache
@@ -115,8 +111,10 @@ jobs:
       - name: Parallel Setup (Supabase & Playwright)
         run: |
           supabase start &
+          S_PID=$!
           (pnpm install --frozen-lockfile && [ "${{ steps.playwright-cache.outputs.cache-hit }}" != "true" ] && pnpm exec playwright install --with-deps || pnpm exec playwright install-deps) &
-          wait
+          P_PID=$!
+          wait $S_PID $P_PID
       - name: Load local Supabase env
         run: |
           supabase status -o env | grep ^API_URL= | sed 's/API_URL=/NEXT_PUBLIC_SUPABASE_URL=/' | sed 's/"//g' >> $GITHUB_ENV

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     { name: 'webkit', use: { ...devices['Desktop Safari'] } },
   ],
   webServer: {
-    command: 'pnpm build && pnpm start',
+    command: process.env.PLAYWRIGHT_WEBSERVER_COMMAND || 'pnpm build && pnpm start',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,


### PR DESCRIPTION
This PR optimizes the CI pipeline by significantly reducing the setup time for Playwright and database tests. 

Key improvements:
1. **Parallel Setup**: `supabase start` and `pnpm install` now run concurrently in the test job.
2. **Artifact Reuse**: The `playwright-tests` job now downloads pre-built artifacts from the `build` job, allowing it to use `pnpm start` instead of `pnpm build && pnpm start`.
3. **Browser Caching**: Playwright browser binaries are now cached using `actions/cache`.
4. **Job Consolidation**: `database-tests` (pgTAP and RLS tests) are moved into the `playwright-tests` job, saving ~1 minute by avoiding a second Supabase environment startup.
5. **Configurable WebServer**: `playwright.config.ts` now respects the `PLAYWRIGHT_WEBSERVER_COMMAND` environment variable.

Fixes #106

---
*PR created automatically by Jules for task [12896374659646398173](https://jules.google.com/task/12896374659646398173) started by @shubhambansal013*