### PR TITLE
Reduce Cloudflare Worker size and add CI monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,22 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 20, cache: 'pnpm' }
       - run: pnpm install --frozen-lockfile
-      - name: Build
+      - name: Build (OpenNext)
         env:
           NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy
-        run: pnpm build
+        run: pnpm opennextjs-cloudflare build
+      - name: Check Worker Size
+        run: |
+          # Cloudflare free plan limit is 3MB (gzipped)
+          # We check the handler size as it's the main contributor
+          SIZE=$(gzip -c .open-next/server-functions/default/handler.mjs | wc -c)
+          LIMIT=3145728 # 3 MiB
+          echo "Worker handler gzipped size: $SIZE bytes"
+          if [ "$SIZE" -gt "$LIMIT" ]; then
+            echo "Error: Worker size exceeds 3MB limit!"
+            exit 1
+          fi
 
   database-tests:
     runs-on: ubuntu-latest

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,15 @@ for the full repo map. Key directories:
 - CI (`.github/workflows/ci.yml`) runs lint/typecheck/unit on every PR,
   RLS tests against a local Supabase spin-up, and Playwright e2e on PRs
   to `main`.
+- **Worker Size Monitoring:** The CI build job verifies that the gzipped size of the Cloudflare Worker handler stays under the 3 MiB limit imposed by the Cloudflare Workers Free plan.
+
+## Deployment & Worker Limits
+
+- **Platform:** Cloudflare Workers via OpenNext.
+- **Limits:** 3 MiB gzipped bundle size (Free plan).
+- **Optimizations:**
+  - **Dynamic Imports:** Large libraries like `exceljs` are dynamically imported within their respective utility functions to move them out of the main server bundle.
+  - **Package Import Optimization:** `next.config.ts` uses `optimizePackageImports` for `lucide-react` to ensure efficient tree-shaking of icons.
 
 ## Phases
 

--- a/lib/exporters/xlsx.ts
+++ b/lib/exporters/xlsx.ts
@@ -1,5 +1,3 @@
-import ExcelJS from 'exceljs';
-
 export type XlsxColumn<T> = {
   key: keyof T;
   header: string;
@@ -23,6 +21,7 @@ export async function buildXlsx<T>({
   columns,
   rows,
 }: XlsxInput<T>): Promise<ArrayBuffer> {
+  const ExcelJS = (await import('exceljs')).default;
   const wb = new ExcelJS.Workbook();
   const ws = wb.addWorksheet(sheetName);
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,9 @@ const nextConfig: NextConfig = {
   // prints so both the owner and anyone on the same Wi-Fi can load the
   // app during development. Production (`next start`) ignores this list.
   allowedDevOrigins: ['localhost', '127.0.0.1', '10.0.6.19'],
+  experimental: {
+    optimizePackageImports: ['lucide-react'],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This PR reduces the Cloudflare Worker bundle size to ensure it fits within the 3 MiB limit of the free plan. 

Key changes:
1.  **Dependency Optimization:** `exceljs` is now dynamically imported only when needed, moving it out of the main server handler chunk.
2.  **Icon Optimization:** Enabled Next.js package import optimization for `lucide-react` to ensure only used icons are bundled.
3.  **CI Enforcement:** The CI `build` job now performs a full OpenNext build and fails if the gzipped size of the main handler exceeds 3 MiB.
4.  **Architecture Update:** Documented these strategies and the reason for them in the project's architecture guide.

Verification:
- Local OpenNext build gzipped size reduced from ~2.5 MB to ~2.35 MB.
- `pnpm test` and `pnpm typecheck` pass.
- `xlsx.test.ts` passes with the new dynamic import.

Fixes #108

---
*PR created automatically by Jules for task [13377028278098999888](https://jules.google.com/task/13377028278098999888) started by @shubhambansal013*