### PR TITLE
Enhance Toast Visual Distinction

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -233,17 +233,38 @@
  */
 .cn-toast {
   @apply !bg-popover !text-popover-foreground !border-border !shadow-md !rounded-md font-sans !px-4 !py-3;
+  @apply border-l-4;
   --normal-bg: var(--popover);
   --normal-border: var(--border);
   --normal-text: var(--popover-foreground);
 }
 
 .cn-toast[data-type="success"] {
-  @apply !border-primary/50;
+  @apply !border-l-emerald-600 !bg-emerald-50/50 dark:!bg-emerald-950/30;
+}
+.cn-toast[data-type="success"] svg {
+  @apply text-emerald-600;
 }
 
 .cn-toast[data-type="error"] {
-  @apply !border-destructive/50;
+  @apply !border-l-destructive !bg-destructive/10;
+}
+.cn-toast[data-type="error"] svg {
+  @apply text-destructive;
+}
+
+.cn-toast[data-type="info"] {
+  @apply !border-l-sky-600 !bg-sky-50/50 dark:!bg-sky-950/30;
+}
+.cn-toast[data-type="info"] svg {
+  @apply text-sky-600;
+}
+
+.cn-toast[data-type="warning"] {
+  @apply !border-l-amber-600 !bg-amber-50/50 dark:!bg-amber-950/30;
+}
+.cn-toast[data-type="warning"] svg {
+  @apply text-amber-600;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
Enhanced the visual distinction of toasts (snackbars) by adding a 4px left border and subtle background tints based on the toast type (success, error, info, warning). This ensures that users can easily identify the result of an action through peripheral vision, as the toasts were previously very similar in appearance. Success toasts now use emerald green, error toasts use the destructive red, and info/warning use sky blue and amber respectively.

Fixes #112

---
*PR created automatically by Jules for task [9134820223896639728](https://jules.google.com/task/9134820223896639728) started by @shubhambansal013*