### PR TITLE
Add date picker to issue form

### DIFF
--- a/app/(app)/inventory/outward/new/outward-form.tsx
+++ b/app/(app)/inventory/outward/new/outward-form.tsx
@@ -36,6 +36,7 @@ export function IssueForm({ sites, items, parties, locations, workers }: Props) 
   const [pending, startTransition] = useTransition();
 
   const [siteId, setSiteId] = useState<string | null>(sites[0]?.id ?? null);
+  const [issueDate, setIssueDate] = useState(new Date().toLocaleDateString('en-CA'));
   const [itemId, setItemId] = useState<string | null>(null);
   const [qty, setQty] = useState('');
   const [locationId, setLocationId] = useState<string | null>(null);
@@ -88,6 +89,7 @@ export function IssueForm({ sites, items, parties, locations, workers }: Props) 
 
     const base = {
       site_id: siteId,
+      issue_date: issueDate,
       item_id: itemId,
       qty,
       unit: selectedItem?.stock_unit ?? '',
@@ -134,6 +136,17 @@ export function IssueForm({ sites, items, parties, locations, workers }: Props) 
           value={siteId}
           onChange={setSiteId}
           placeholder="Select site"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="issueDate">Date *</Label>
+        <Input
+          id="issueDate"
+          type="date"
+          value={issueDate}
+          onChange={(e) => setIssueDate(e.target.value)}
+          required
         />
       </div>
 


### PR DESCRIPTION
This PR adds a manual date picker to the issue (outward) entry form.

Key changes:
- Added `issueDate` state in `IssueForm`, initialized using `new Date().toLocaleDateString('en-CA')` to ensure consistent `YYYY-MM-DD` formatting across timezones.
- Inserted a new form field with a `Label` and `Input[type="date"]` before the "Item" field, as requested.
- Updated the `onSubmit` handler to include `issue_date` in the payload sent to the `createIssue` server action.
- Verified that the `issueCreateSchema` already supports an optional `issue_date` string.
- Performed cleanup of temporary log files created during verification.

Fixes #115

---
*PR created automatically by Jules for task [5540843580390111248](https://jules.google.com/task/5540843580390111248) started by @shubhambansal013*