### PR TITLE
Fix header overflow on mobile devices

### DIFF
--- a/components/__tests__/app-shell.test.tsx
+++ b/components/__tests__/app-shell.test.tsx
@@ -56,6 +56,7 @@ vi.mock('lucide-react', () => ({
   X: () => <div data-testid="icon-x" />,
   Sun: () => <div data-testid="icon-sun" />,
   Moon: () => <div data-testid="icon-moon" />,
+  LogOut: () => <div data-testid="icon-logout" />,
 }));
 
 vi.mock('../site-switcher', () => ({

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -28,6 +28,7 @@ import {
   BarChart3,
   Menu,
   X,
+  LogOut,
 } from 'lucide-react';
 import type { ModuleId, ActionId } from '@/lib/permissions/types';
 
@@ -217,7 +218,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="bg-muted/30 flex min-h-screen flex-col">
       <header className="print:hide bg-card sticky top-0 z-30 flex h-12 items-center justify-between border-b px-3 sm:px-4">
-        <div className="flex items-center gap-2 sm:gap-5">
+        <div className="flex shrink-0 items-center gap-2 sm:gap-5">
           <Button
             type="button"
             variant="ghost"
@@ -230,15 +231,22 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           >
             <Menu className="h-5 w-5" aria-hidden />
           </Button>
-          <Link href="/dashboard" aria-label={`${APP_NAME} home`} className="flex items-baseline gap-1.5">
+          <Link href="/dashboard" aria-label={`${APP_NAME} home`} className="flex shrink-0 items-baseline gap-1.5">
             <span className="text-primary font-mono text-base font-bold tracking-tight">{APP_NAME}</span>
           </Link>
           <SiteSwitcher />
         </div>
-        <div className="flex items-center gap-1 sm:gap-2">
+        <div className="flex shrink-0 items-center gap-0.5 sm:gap-1">
           <ModeToggle />
-          <Button variant="ghost" size="sm" onClick={signOut} className="min-h-11 md:h-8">
-            Sign out
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={signOut}
+            className="min-h-11 px-2 md:h-8 md:px-2.5"
+            aria-label="Sign out"
+          >
+            <LogOut className="h-4 w-4 md:mr-2" aria-hidden />
+            <span className="hidden md:inline">Sign out</span>
           </Button>
         </div>
       </header>

--- a/components/site-switcher.tsx
+++ b/components/site-switcher.tsx
@@ -46,7 +46,7 @@ export function SiteSwitcher() {
         if (s) setCurrentSite(s);
       }}
     >
-      <SelectTrigger className="w-[220px]">
+      <SelectTrigger className="w-[130px] sm:w-[220px]">
         <SelectValue placeholder="Select site">
           {currentSite ? `${currentSite.code} — ${currentSite.name}` : null}
         </SelectValue>


### PR DESCRIPTION
This PR fixes a layout regression where the app header would overflow on small mobile devices (e.g., iPhone SE) after the addition of the theme toggle.

Key changes:
- **Responsive SiteSwitcher:** The site selection dropdown now takes up less space on narrow viewports (`130px` vs `220px`).
- **Icon-only Sign out on Mobile:** The "Sign out" button now displays only a `LogOut` icon on mobile screens, with a hidden text label.
- **Accessibility:** Added `aria-label="Sign out"` to the button to ensure it remains accessible to screen reader users when the text is hidden.
- **Layout Stability:** Added `shrink-0` to the logo and header action containers to ensure they don't get squashed, and tightened gaps to reclaim space.
- **Test Fix:** Updated the `AppShell` unit tests to include the `LogOut` icon in the `lucide-react` mock.

Fixes #114

---
*PR created automatically by Jules for task [7143783205296826788](https://jules.google.com/task/7143783205296826788) started by @shubhambansal013*