### PR TITLE
Implement reusable paginated table and apply to items

### DIFF
--- a/app/(app)/masters/items/items-client.tsx
+++ b/app/(app)/masters/items/items-client.tsx
@@ -5,6 +5,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { MasterShell } from '@/components/master-shell';
 import { DataGrid } from '@/components/data-grid';
 import { EmptyState } from '@/components/empty-state';
+import { useOptimalPageSize } from '@/lib/hooks/use-optimal-page-size';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { ItemForm } from './item-form';
@@ -36,6 +37,7 @@ export function ItemsClient({ items, categories, units }: Props) {
   const [search, setSearch] = useState('');
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<ItemWithCategory | null>(null);
+  const optimalPageSize = useOptimalPageSize();
 
   const filtered = useMemo(() => {
     if (!search.trim()) return items;
@@ -129,7 +131,7 @@ export function ItemsClient({ items, categories, units }: Props) {
             data={filtered}
             showRowNumbers
             pagination
-            pageSize={50}
+            pageSize={optimalPageSize}
             onRowClick={(item) => {
               setEditing(item);
               setSheetOpen(true);

--- a/app/(app)/masters/items/items-client.tsx
+++ b/app/(app)/masters/items/items-client.tsx
@@ -101,21 +101,6 @@ export function ItemsClient({ items, categories, units }: Props) {
     setEditing(null);
   };
 
-  // Event delegation: find the <tr> ancestor of the clicked element,
-  // then map its tbody row-index to the filtered data array.
-  const handleTableClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    const tr = (e.target as HTMLElement).closest('tbody tr');
-    if (!tr) return;
-    const tbody = tr.closest('tbody');
-    if (!tbody) return;
-    const rowIndex = Array.from(tbody.querySelectorAll('tr')).indexOf(tr as HTMLTableRowElement);
-    const item = filtered[rowIndex];
-    if (item) {
-      setEditing(item);
-      setSheetOpen(true);
-    }
-  };
-
   return (
     <div className="space-y-4">
       <header>
@@ -139,17 +124,18 @@ export function ItemsClient({ items, categories, units }: Props) {
             action={<Button onClick={openCreate}>+ New item</Button>}
           />
         ) : (
-          <div
-            onClick={handleTableClick}
-            className="[&_tbody_tr:hover]:bg-muted/50 [&_tbody_tr]:cursor-pointer"
-          >
-            <DataGrid
-              columns={columns}
-              data={filtered}
-              showRowNumbers
-              emptyMessage="No items match your search."
-            />
-          </div>
+          <DataGrid
+            columns={columns}
+            data={filtered}
+            showRowNumbers
+            pagination
+            pageSize={50}
+            onRowClick={(item) => {
+              setEditing(item);
+              setSheetOpen(true);
+            }}
+            emptyMessage="No items match your search."
+          />
         )}
       </MasterShell>
 

--- a/components/__tests__/data-grid.test.tsx
+++ b/components/__tests__/data-grid.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import type { ColumnDef } from '@tanstack/react-table';
 import { DataGrid } from '../data-grid';
 
@@ -31,5 +31,37 @@ describe('DataGrid', () => {
   it('renders empty state when data is empty', () => {
     render(<DataGrid columns={cols} data={[]} emptyMessage="Nothing here" />);
     expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('calls onRowClick when a row is clicked', () => {
+    const onRowClick = vi.fn();
+    render(<DataGrid columns={cols} data={rows} onRowClick={onRowClick} />);
+
+    const row = screen.getByText('Cement').closest('tr');
+    fireEvent.click(row!);
+
+    expect(onRowClick).toHaveBeenCalledWith(rows[0], 0);
+  });
+
+  it('supports pagination', () => {
+    const manyRows = Array.from({ length: 11 }, (_, i) => ({ name: `Item ${i}`, qty: i }));
+    render(<DataGrid columns={cols} data={manyRows} pagination pageSize={10} />);
+
+    // First page should have Item 0 to Item 9
+    expect(screen.getByText('Item 0')).toBeInTheDocument();
+    expect(screen.getByText('Item 9')).toBeInTheDocument();
+    expect(screen.queryByText('Item 10')).not.toBeInTheDocument();
+
+    // Should show page info
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+
+    // Go to next page
+    const nextButton = screen.getByRole('button', { name: /next page/i });
+    fireEvent.click(nextButton);
+
+    // Second page should have Item 10
+    expect(screen.getByText('Item 10')).toBeInTheDocument();
+    expect(screen.queryByText('Item 0')).not.toBeInTheDocument();
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
   });
 });

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -4,16 +4,30 @@ import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
+  getPaginationRowModel,
   SortingState,
   useReactTable,
 } from '@tanstack/react-table';
 import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
 
 type Props<T> = {
   columns: ColumnDef<T, unknown>[];
   data: T[];
   showRowNumbers?: boolean;
   emptyMessage?: string;
+  pagination?: boolean;
+  pageSize?: number;
+  onRowClick?: (row: T, index: number) => void;
 };
 
 /**
@@ -25,15 +39,20 @@ type Props<T> = {
  *   - Click column header to sort (ascending → descending → none)
  *   - Optional row-number gutter (`showRowNumbers`) — mimics Excel's
  *     "#" column on the far left
+ *   - Optional pagination (`pagination`)
+ *   - Row click handler (`onRowClick`) with accessibility support
  *
- * The grid itself only handles rendering and sorting. Filtering,
- * pagination, and inline edit are composed by the consuming screen.
+ * The grid itself handles rendering, sorting, and pagination. Filtering
+ * and inline edit are composed by the consuming screen.
  */
 export function DataGrid<T>({
   columns,
   data,
   showRowNumbers = false,
   emptyMessage = 'No rows',
+  pagination = false,
+  pageSize = 50,
+  onRowClick,
 }: Props<T>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   // TanStack Table intentionally returns non-memoizable functions; the
@@ -47,6 +66,12 @@ export function DataGrid<T>({
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: pagination ? getPaginationRowModel() : undefined,
+    initialState: {
+      pagination: {
+        pageSize: pageSize,
+      },
+    },
   });
 
   if (!data.length) {
@@ -54,36 +79,120 @@ export function DataGrid<T>({
   }
 
   return (
-    <div className="overflow-auto">
-      <table className="excel-grid w-full border-collapse">
-        <thead>
-          {table.getHeaderGroups().map((hg) => (
-            <tr key={hg.id}>
-              {showRowNumbers && <th className="row-num w-10">#</th>}
-              {hg.headers.map((h) => (
-                <th
-                  key={h.id}
-                  onClick={h.column.getToggleSortingHandler()}
-                  className="cursor-pointer select-none"
-                >
-                  {flexRender(h.column.columnDef.header, h.getContext())}
-                  {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row, i) => (
-            <tr key={row.id}>
-              {showRowNumbers && <td className="row-num">{i + 1}</td>}
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="space-y-4">
+      <div className="overflow-auto border-b border-border">
+        <table className="excel-grid w-full border-collapse border-b-0">
+          <thead>
+            {table.getHeaderGroups().map((hg) => (
+              <tr key={hg.id}>
+                {showRowNumbers && <th className="row-num w-10">#</th>}
+                {hg.headers.map((h) => (
+                  <th
+                    key={h.id}
+                    onClick={h.column.getToggleSortingHandler()}
+                    className="cursor-pointer select-none"
+                  >
+                    {flexRender(h.column.columnDef.header, h.getContext())}
+                    {{ asc: ' ▲', desc: ' ▼' }[h.column.getIsSorted() as string] ?? ''}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody className={cn(onRowClick && '[&_tr]:cursor-pointer')}>
+            {table.getRowModel().rows.map((row) => (
+              <tr
+                key={row.id}
+                onClick={() => onRowClick?.(row.original, row.index)}
+                onKeyDown={(e) => {
+                  if (onRowClick && (e.key === 'Enter' || e.key === ' ')) {
+                    e.preventDefault();
+                    onRowClick(row.original, row.index);
+                  }
+                }}
+                role={onRowClick ? 'button' : undefined}
+                tabIndex={onRowClick ? 0 : undefined}
+                className={cn(
+                  onRowClick && 'hover:bg-muted/50 focus:bg-muted/50 outline-hidden',
+                )}
+              >
+                {showRowNumbers && <td className="row-num">{row.index + 1}</td>}
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {pagination && (
+        <div className="print:hide flex items-center justify-between px-2">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>Show</span>
+            <Select
+              value={table.getState().pagination.pageSize.toString()}
+              onValueChange={(v) => table.setPageSize(Number(v))}
+            >
+              <SelectTrigger size="sm" className="w-[70px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="start">
+                {[10, 25, 50, 100].map((size) => (
+                  <SelectItem key={size} value={size.toString()}>
+                    {size}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span>per page</span>
+          </div>
+
+          <div className="flex items-center gap-6 lg:gap-8">
+            <div className="flex items-center justify-center text-sm font-medium">
+              Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                className="hidden h-8 w-8 p-0 lg:flex"
+                onClick={() => table.setPageIndex(0)}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">Go to first page</span>
+                <ChevronsLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                className="h-8 w-8 p-0"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">Go to previous page</span>
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                className="h-8 w-8 p-0"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">Go to next page</span>
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                className="hidden h-8 w-8 p-0 lg:flex"
+                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">Go to last page</span>
+                <ChevronsRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -66,7 +66,7 @@ export function DataGrid<T>({
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    getPaginationRowModel: pagination ? getPaginationRowModel() : undefined,
+    ...(pagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
     initialState: {
       pagination: {
         pageSize: pageSize,

--- a/lib/hooks/use-optimal-page-size.ts
+++ b/lib/hooks/use-optimal-page-size.ts
@@ -1,0 +1,29 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook to calculate an optimal page size based on the available viewport height.
+ * It assumes a fixed header/footer height and a standard row height.
+ *
+ * @param rowHeight The approximate height of a single table row in pixels (default 32 for dense excel-grid).
+ * @param offsetHeight The total height of other elements on the page (header, search bar, pagination controls) in pixels.
+ * @returns The calculated page size.
+ */
+export function useOptimalPageSize(rowHeight = 32, offsetHeight = 280) {
+  const [pageSize, setPageSize] = useState(50);
+
+  useEffect(() => {
+    const calculate = () => {
+      const availableHeight = window.innerHeight - offsetHeight;
+      const count = Math.floor(availableHeight / rowHeight);
+      // Clamp to reasonable values
+      setPageSize(Math.max(10, Math.min(100, count)));
+    };
+
+    calculate();
+    window.addEventListener('resize', calculate);
+    return () => window.removeEventListener('resize', calculate);
+  }, [rowHeight, offsetHeight]);
+
+  return pageSize;
+}


### PR DESCRIPTION
I have implemented a reusable paginated table by enhancing the existing `DataGrid` component.

Key changes:
- **`DataGrid` enhancement**: Integrated TanStack Table's `getPaginationRowModel` and added a pagination control bar at the bottom.
- **Improved UX**: Added an `onRowClick` handler to `DataGrid` which handles both mouse clicks and keyboard (Enter/Space) interactions for better accessibility.
- **Items master update**: Switched the items master table to use the new paginated mode and replaced the manual event delegation with the new `onRowClick` prop.
- **Testing**: Added comprehensive tests for the new features in `components/__tests__/data-grid.test.tsx`.

The implementation is backward-compatible as the `pagination` prop defaults to `false`.

Fixes #119

---
*PR created automatically by Jules for task [12486807166093193708](https://jules.google.com/task/12486807166093193708) started by @shubhambansal013*