### PR TITLE
Fix DataGrid page size reactivity and standardize master pages pagination

### DIFF
--- a/app/(app)/masters/locations/locations-client.tsx
+++ b/app/(app)/masters/locations/locations-client.tsx
@@ -7,6 +7,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { MasterShell } from '@/components/master-shell';
 import { DataGrid } from '@/components/data-grid';
 import { EmptyState } from '@/components/empty-state';
+import { useOptimalPageSize } from '@/lib/hooks/use-optimal-page-size';
 import { LocationForm } from './location-form';
 
 type Unit = {
@@ -58,6 +59,7 @@ export function LocationsClient({ units, sites, types }: Props) {
   const [search, setSearch] = useState('');
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<Unit | null>(null);
+  const pageSize = useOptimalPageSize();
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase();
@@ -129,7 +131,13 @@ export function LocationsClient({ units, sites, types }: Props) {
             }
           />
         ) : (
-          <DataGrid columns={columns} data={filtered} showRowNumbers />
+          <DataGrid
+            columns={columns}
+            data={filtered}
+            showRowNumbers
+            pagination
+            pageSize={pageSize}
+          />
         )}
       </MasterShell>
 

--- a/app/(app)/masters/parties/parties-client.tsx
+++ b/app/(app)/masters/parties/parties-client.tsx
@@ -7,6 +7,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { MasterShell } from '@/components/master-shell';
 import { DataGrid } from '@/components/data-grid';
 import { EmptyState } from '@/components/empty-state';
+import { useOptimalPageSize } from '@/lib/hooks/use-optimal-page-size';
 import { PartyForm } from './party-form';
 
 type Party = {
@@ -75,6 +76,7 @@ export function PartiesClient({ parties, partyTypes }: Props) {
   const [search, setSearch] = useState('');
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<Party | null>(null);
+  const pageSize = useOptimalPageSize();
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase();
@@ -148,7 +150,13 @@ export function PartiesClient({ parties, partyTypes }: Props) {
             }
           />
         ) : (
-          <DataGrid columns={columns} data={filtered} showRowNumbers />
+          <DataGrid
+            columns={columns}
+            data={filtered}
+            showRowNumbers
+            pagination
+            pageSize={pageSize}
+          />
         )}
       </MasterShell>
 

--- a/app/(app)/masters/sites/sites-client.tsx
+++ b/app/(app)/masters/sites/sites-client.tsx
@@ -7,6 +7,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { MasterShell } from '@/components/master-shell';
 import { DataGrid } from '@/components/data-grid';
 import { EmptyState } from '@/components/empty-state';
+import { useOptimalPageSize } from '@/lib/hooks/use-optimal-page-size';
 import type { Tables } from '@/lib/supabase/types';
 import { SiteForm } from './site-form';
 
@@ -58,6 +59,7 @@ export function SitesClient({ sites }: Props) {
   const [search, setSearch] = useState('');
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<Site | null>(null);
+  const pageSize = useOptimalPageSize();
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -128,7 +130,13 @@ export function SitesClient({ sites }: Props) {
             }
           />
         ) : (
-          <DataGrid columns={columns} data={filtered} showRowNumbers />
+          <DataGrid
+            columns={columns}
+            data={filtered}
+            showRowNumbers
+            pagination
+            pageSize={pageSize}
+          />
         )}
       </MasterShell>
 

--- a/app/(app)/masters/units/units-client.tsx
+++ b/app/(app)/masters/units/units-client.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import { MasterShell } from '@/components/master-shell';
 import { DataGrid } from '@/components/data-grid';
 import { EmptyState } from '@/components/empty-state';
+import { useOptimalPageSize } from '@/lib/hooks/use-optimal-page-size';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { ConfirmDialog } from '@/components/confirm-dialog';
@@ -39,6 +40,7 @@ export function UnitsClient({ units }: Props) {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<UnitRow | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<UnitRow | null>(null);
+  const pageSize = useOptimalPageSize();
 
   const filtered = useMemo(() => {
     if (!search.trim()) return units;
@@ -95,20 +97,6 @@ export function UnitsClient({ units }: Props) {
     setEditing(null);
   };
 
-  // Event delegation — mirrors the pattern in items-client.tsx
-  const handleTableClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    const tr = (e.target as HTMLElement).closest('tbody tr');
-    if (!tr) return;
-    const tbody = tr.closest('tbody');
-    if (!tbody) return;
-    const rowIndex = Array.from(tbody.querySelectorAll('tr')).indexOf(tr as HTMLTableRowElement);
-    const unit = filtered[rowIndex];
-    if (unit) {
-      setEditing(unit);
-      setSheetOpen(true);
-    }
-  };
-
   const handleDelete = async () => {
     if (!deleteTarget) return;
     const res = await deleteUnit(deleteTarget.id);
@@ -146,17 +134,18 @@ export function UnitsClient({ units }: Props) {
             action={<Button onClick={openCreate}>+ New unit</Button>}
           />
         ) : (
-          <div
-            onClick={handleTableClick}
-            className="[&_tbody_tr:hover]:bg-muted/50 [&_tbody_tr]:cursor-pointer"
-          >
-            <DataGrid
-              columns={columns}
-              data={filtered}
-              showRowNumbers
-              emptyMessage="No units match your search."
-            />
-          </div>
+          <DataGrid
+            columns={columns}
+            data={filtered}
+            showRowNumbers
+            pagination
+            pageSize={pageSize}
+            onRowClick={(unit) => {
+              setEditing(unit);
+              setSheetOpen(true);
+            }}
+            emptyMessage="No units match your search."
+          />
         )}
       </MasterShell>
 

--- a/app/(app)/masters/workers/workers-client.tsx
+++ b/app/(app)/masters/workers/workers-client.tsx
@@ -18,6 +18,7 @@ import { Label } from '@/components/ui/label';
 import { MasterShell } from '@/components/master-shell';
 import { DataGrid } from '@/components/data-grid';
 import { EmptyState } from '@/components/empty-state';
+import { useOptimalPageSize } from '@/lib/hooks/use-optimal-page-size';
 import { SearchableSelect } from '@/components/searchable-select';
 import { WorkerForm } from './worker-form';
 import { transferWorker, changeAffiliation } from './actions';
@@ -99,6 +100,7 @@ export function WorkersClient({ workers, sites, parties }: Props) {
   const [editing, setEditing] = useState<Worker | null>(null);
   const [transferFor, setTransferFor] = useState<Worker | null>(null);
   const [affiliateFor, setAffiliateFor] = useState<Worker | null>(null);
+  const pageSize = useOptimalPageSize();
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -184,6 +186,8 @@ export function WorkersClient({ workers, sites, parties }: Props) {
             columns={columns}
             data={filtered}
             showRowNumbers
+            pagination
+            pageSize={pageSize}
             emptyMessage="No workers match your search."
           />
         )}

--- a/components/__tests__/data-grid.test.tsx
+++ b/components/__tests__/data-grid.test.tsx
@@ -64,4 +64,21 @@ describe('DataGrid', () => {
     expect(screen.queryByText('Item 0')).not.toBeInTheDocument();
     expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
   });
+
+  it('updates page size when pageSize prop changes', () => {
+    const manyRows = Array.from({ length: 20 }, (_, i) => ({ name: `Item ${i}`, qty: i }));
+    const { rerender } = render(<DataGrid columns={cols} data={manyRows} pagination pageSize={5} />);
+
+    // Initially should show 5 items
+    expect(screen.getByText('Item 0')).toBeInTheDocument();
+    expect(screen.getByText('Item 4')).toBeInTheDocument();
+    expect(screen.queryByText('Item 5')).not.toBeInTheDocument();
+
+    // Rerender with pageSize 10
+    rerender(<DataGrid columns={cols} data={manyRows} pagination pageSize={10} />);
+
+    // Should now show 10 items
+    expect(screen.getByText('Item 9')).toBeInTheDocument();
+    expect(screen.queryByText('Item 10')).not.toBeInTheDocument();
+  });
 });

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -8,7 +8,7 @@ import {
   SortingState,
   useReactTable,
 } from '@tanstack/react-table';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import {
@@ -73,6 +73,12 @@ export function DataGrid<T>({
       },
     },
   });
+
+  useEffect(() => {
+    if (pagination && pageSize) {
+      table.setPageSize(pageSize);
+    }
+  }, [table, pagination, pageSize]);
 
   if (!data.length) {
     return <div className="p-8 text-center text-sm text-gray-500">{emptyMessage}</div>;


### PR DESCRIPTION
Fixed a bug where the Items page (and other master pages) would default to a page size of 50 regardless of the screen size, despite using the `useOptimalPageSize` hook. The issue was that the `DataGrid` component only used the `pageSize` prop for its initial state and did not react to subsequent prop changes.

Changes:
1.  **DataGrid Fix**: Added a `useEffect` to `components/data-grid.tsx` that calls `table.setPageSize(pageSize)` whenever the `pageSize` prop changes.
2.  **Standardized Master Pages**: Updated `Sites`, `Locations`, `Workers`, `Units`, and `Parties` client components to use the `useOptimalPageSize` hook and enable pagination on their `DataGrid` instances.
3.  **Refactored Units Page**: Cleaned up manual DOM event delegation for row clicks in `UnitsClient` and switched to the standard `onRowClick` prop provided by `DataGrid`.
4.  **Regression Test**: Added a new test case to `components/__tests__/data-grid.test.tsx` to verify that `DataGrid` correctly updates its internal page size when the `pageSize` prop is updated.

Fixes #122

---
*PR created automatically by Jules for task [15181637226509708708](https://jules.google.com/task/15181637226509708708) started by @shubhambansal013*