### PR TITLE
Restrict destructive schema changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,12 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
-  migrate:
+  check-migrations:
     needs: ci
     runs-on: ubuntu-latest
-    name: Run Supabase Migrations
+    name: Check for Destructive Migrations
+    outputs:
+      destructive: ${{ steps.check.outputs.destructive }}
     environment: ${{ github.ref_name == 'main' && 'prod' || 'staging' }}
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -33,16 +35,62 @@ jobs:
       - name: Link Supabase project
         run: supabase link --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD
 
-      - name: Dry run migrations
-        run: supabase db push --dry-run
+      - name: Run Safety Check
+        id: check
+        run: ./supabase/scripts/check-destructive.sh
 
+  migrate-safe:
+    needs: check-migrations
+    if: needs.check-migrations.outputs.destructive == 'false'
+    runs-on: ubuntu-latest
+    name: Run Safe Migrations
+    environment: ${{ github.ref_name == 'main' && 'prod' || 'staging' }}
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Link Supabase project
+        run: supabase link --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD
       - name: Apply migrations
+        run: supabase db push
+
+  migrate-destructive:
+    needs: check-migrations
+    if: needs.check-migrations.outputs.destructive == 'true'
+    runs-on: ubuntu-latest
+    name: Run Destructive Migrations (Manual Approval)
+    # Using a separate environment to enforce manual approval gates
+    environment: ${{ github.ref_name == 'main' && 'prod-destructive' || 'staging-destructive' }}
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Link Supabase project
+        run: supabase link --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD
+      - name: Apply destructive migrations
         run: supabase db push
 
   deploy:
     runs-on: ubuntu-latest
     name: Deploy to Cloudflare
-    needs: migrate
+    needs: [migrate-safe, migrate-destructive]
+    if: |
+      always() &&
+      (needs.migrate-safe.result == 'success' || needs.migrate-destructive.result == 'success')
     environment: ${{ github.ref_name == 'main' && 'prod' || 'staging' }}
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -46,11 +46,23 @@ Create environments for `prod` and `staging` to manage these values per-branch.
 
 The deployment is managed by `.github/workflows/deploy.yml` and triggers automatically on pushes to `main` (production) and `staging` branches.
 
-### Step 4a: Database Migrations (`migrate` job)
-The workflow uses the Supabase CLI to apply migrations:
-1. Links to the remote project using `SUPABASE_PROJECT_ID` and `SUPABASE_DB_PASSWORD`.
-2. Performs a dry run of the migrations.
-3. Applies all pending migrations in `supabase/migrations/` to the remote database using `supabase db push`.
+### Step 4a: Database Migrations
+
+The workflow implements a safety check to prevent automatic destructive schema changes.
+
+1.  **Safety Check (`check-migrations` job):**
+    -   Links to the remote project.
+    -   Scans pending migrations for destructive SQL keywords (`DROP`, `TRUNCATE`).
+    -   Sets a `destructive` output flag.
+
+2.  **Safe Migrations (`migrate-safe` job):**
+    -   Runs automatically if no destructive changes are detected.
+    -   Applies migrations using `supabase db push`.
+
+3.  **Destructive Migrations (`migrate-destructive` job):**
+    -   Triggered if destructive changes are detected.
+    -   Requires **manual approval** via GitHub Environment gates (`prod-destructive` or `staging-destructive`).
+    -   Once approved, applies migrations using `supabase db push`.
 
 ### Step 4b: Cloudflare Deployment (`deploy` job)
 Once migrations are successful, the app is built and deployed:

--- a/supabase/scripts/check-destructive.sh
+++ b/supabase/scripts/check-destructive.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+# check-destructive.sh
+# Scans pending Supabase migrations for destructive SQL commands.
+# Keywords: DROP TABLE, DROP COLUMN, TRUNCATE, DROP SCHEMA, DROP DATABASE, etc.
+
+echo "Checking for destructive migrations..."
+
+# Run dry-run and capture output.
+# In CI, 'supabase link' must have been run before this.
+DRY_RUN_OUTPUT=$(supabase db push --dry-run 2>&1 || echo "")
+
+if [ -z "$DRY_RUN_OUTPUT" ]; then
+  echo "No output from dry-run. Assuming no pending migrations."
+  if [ -n "$GITHUB_OUTPUT" ]; then
+    echo "destructive=false" >> "$GITHUB_OUTPUT"
+  fi
+  exit 0
+fi
+
+# Extract filenames (timestamp_name.sql) from the output.
+PENDING_MIGRATIONS=$(echo "$DRY_RUN_OUTPUT" | grep -oE '[0-9]{14}_[^ ]+\.sql' | sort -u)
+
+if [ -z "$PENDING_MIGRATIONS" ]; then
+  echo "No pending migrations found."
+  if [ -n "$GITHUB_OUTPUT" ]; then
+    echo "destructive=false" >> "$GITHUB_OUTPUT"
+  fi
+  exit 0
+fi
+
+echo "Pending migrations:"
+echo "$PENDING_MIGRATIONS"
+
+DESTRUCTIVE_FOUND=false
+
+# Regex for destructive keywords.
+# 1. DROP (TABLE|COLUMN|SCHEMA|DATABASE|TYPE|VIEW|INDEX|FUNCTION|TRIGGER|POLICY|EXTENSION)
+# 2. ALTER TABLE ... DROP ... (covers DROP COLUMN without the COLUMN keyword)
+# 3. TRUNCATE
+# Using basic case-insensitive grep with simplified patterns for robustness.
+KEYWORDS="DROP|TRUNCATE"
+
+for MIGRATION in $PENDING_MIGRATIONS; do
+  FILE="supabase/migrations/$MIGRATION"
+  if [ -f "$FILE" ]; then
+    # Search for keywords while ignoring comments (lines starting with --)
+    MATCHES=$(grep -iE "$KEYWORDS" "$FILE" | grep -v "^\s*--" || true)
+
+    if [ -n "$MATCHES" ]; then
+      # Narrow down to actually destructive DROP/TRUNCATE.
+      # We look for "DROP [object]" or "TRUNCATE".
+      # This may catch some false positives but errs on the side of safety.
+      if echo "$MATCHES" | grep -iE "DROP\s+|TRUNCATE" > /dev/null; then
+        echo "⚠️  DESTRUCTIVE CHANGE DETECTED in $MIGRATION:"
+        echo "$MATCHES"
+        DESTRUCTIVE_FOUND=true
+      fi
+    fi
+  else
+    echo "Warning: Migration file $FILE not found locally."
+  fi
+done
+
+if [ "$DESTRUCTIVE_FOUND" = true ]; then
+  echo "Outcome: Destructive changes found. Human approval required."
+  if [ -n "$GITHUB_OUTPUT" ]; then
+    echo "destructive=true" >> "$GITHUB_OUTPUT"
+  fi
+else
+  echo "Outcome: No destructive changes detected."
+  if [ -n "$GITHUB_OUTPUT" ]; then
+    echo "destructive=false" >> "$GITHUB_OUTPUT"
+  fi
+fi


### PR DESCRIPTION
This PR implements a safety mechanism to prevent automatic destructive database schema changes during deployment. 

Key changes:
1.  **Destructive Change Detection**: A new bash script `supabase/scripts/check-destructive.sh` uses the Supabase CLI's dry-run feature to identify pending migrations and scans them for destructive SQL keywords (e.g., `DROP`, `TRUNCATE`).
2.  **Gated Deployment Workflow**: The `.github/workflows/deploy.yml` file has been restructured. Migrations are now processed in three stages:
    -   **Check**: Identifies if destructive changes are present.
    -   **Safe Path**: Automatically applies migrations if no destructive changes are found.
    -   **Destructive Path**: Routes migrations containing destructive changes to a job requiring manual approval via GitHub Environment protection rules (`prod-destructive` and `staging-destructive`).
3.  **Documentation**: The deployment runbook (`docs/runbooks/deploy.md`) has been updated to explain the new safety check and manual approval process.

This ensures that any operation that could lead to data loss is explicitly reviewed and approved by a human before execution.

Fixes #124

---
*PR created automatically by Jules for task [14508138906879529180](https://jules.google.com/task/14508138906879529180) started by @shubhambansal013*