### PR TITLE
Fix masking of worker validation errors

### DIFF
--- a/app/(app)/masters/workers/actions.ts
+++ b/app/(app)/masters/workers/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 import { runAction } from '@/lib/actions/shared';
+import { ActionError } from '@/lib/actions/errors';
 import {
   workerCreateSchema,
   workerUpdateSchema,
@@ -213,10 +214,10 @@ function validateTransfer(
   input: { to_site_id: string; effective_from: string },
 ) {
   if (open.site_id === input.to_site_id) {
-    throw new Error('Destination site is the same as the current site');
+    throw new ActionError('Destination site is the same as the current site');
   }
   if (input.effective_from <= open.effective_from) {
-    throw new Error('New effective_from must be after current placement start');
+    throw new ActionError('New effective_from must be after current placement start');
   }
 }
 
@@ -254,13 +255,13 @@ function validateAffiliationChange(
   },
 ) {
   if (input.effective_from <= open.effective_from) {
-    throw new Error('New effective_from must be after current affiliation start');
+    throw new ActionError('New effective_from must be after current affiliation start');
   }
   if (
     open.employment_type === input.employment_type &&
     (open.contractor_party_id ?? null) === (input.contractor_party_id ?? null)
   ) {
-    throw new Error('New affiliation is identical to the current one');
+    throw new ActionError('New affiliation is identical to the current one');
   }
 }
 

--- a/lib/actions/errors.ts
+++ b/lib/actions/errors.ts
@@ -17,6 +17,17 @@
  * reach it via `shared.ts`, which is itself `'server-only'`.
  */
 
+/**
+ * Custom error class for expected validation or business logic
+ * failures that should be displayed directly to the user.
+ */
+export class ActionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ActionError';
+  }
+}
+
 const MESSAGES: Record<string, string> = {
   // insufficient_privilege — raised by RLS WITH CHECK / USING denials.
   '42501': 'You do not have permission to perform this action.',
@@ -60,7 +71,7 @@ function extractCode(e: unknown): string | null {
   // Some pg wrappers stringify SQLSTATE into .message.
   if (typeof obj.message === 'string') {
     const msg = obj.message;
-    const match = msg.match(/SQLSTATE\s+(\d{5})/i);
+    const match = msg.match(/SQLSTATE\s+([A-Z0-9]{5})/i);
     if (match && match[1]) return match[1];
     for (const [re, code] of MESSAGE_PATTERNS) {
       if (re.test(msg)) return code;
@@ -72,6 +83,11 @@ function extractCode(e: unknown): string | null {
 export function safeErrorMessage(e: unknown): string {
   // Server-only log — keeps the debugging trail outside of client toasts.
   console.error('[safeErrorMessage]', e);
+
+  if (e instanceof ActionError) {
+    return e.message;
+  }
+
   const code = extractCode(e);
   if (code && code in MESSAGES) {
     const mapped = MESSAGES[code];

--- a/tests/lib/actions/errors.test.ts
+++ b/tests/lib/actions/errors.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { safeErrorMessage, ActionError } from '@/lib/actions/errors';
+
+describe('safeErrorMessage', () => {
+  // Silence console.error for tests
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  it('passes through messages from ActionError instances', () => {
+    const msg = 'This is a safe error message';
+    const err = new ActionError(msg);
+    expect(safeErrorMessage(err)).toBe(msg);
+  });
+
+  it('maps known Postgres error codes to user-friendly messages', () => {
+    const pgError = { code: '23505', message: 'duplicate key value violates unique constraint' };
+    expect(safeErrorMessage(pgError)).toBe('A record with these details already exists.');
+  });
+
+  it('extracts Postgres error codes from stringified messages', () => {
+    // Test regex SQLSTATE \s+ (\d{5})
+    const rethrown = { message: 'Database error: SQLSTATE 23P01' };
+    expect(safeErrorMessage(rethrown)).toBe('A record with overlapping dates already exists.');
+  });
+
+  it('returns a generic message for unknown errors', () => {
+    const unknownErr = new Error('Something very bad happened internally');
+    expect(safeErrorMessage(unknownErr)).toBe('Something went wrong. Please try again.');
+  });
+
+  it('returns a generic message for null or non-object inputs', () => {
+    expect(safeErrorMessage(null)).toBe('Something went wrong. Please try again.');
+    expect(safeErrorMessage('just a string')).toBe('Something went wrong. Please try again.');
+  });
+});


### PR DESCRIPTION
The "Something went wrong" error was caused by the application's security-first error handling, which masks any unrecognized `Error` thrown in a server action as a generic message. I've introduced an `ActionError` class that signals when an error message is safe to display to the user. I then updated the worker affiliation and transfer logic to use this new class for validation failures. Additionally, I improved the Postgres error code extraction to correctly handle alphanumeric codes like `23P01` (exclusion violations).

Fixes #130

---
*PR created automatically by Jules for task [17749355277051676995](https://jules.google.com/task/17749355277051676995) started by @shubhambansal013*