### PR TITLE
Improve error messaging for worker actions

### DIFF
--- a/app/(app)/masters/workers/actions.ts
+++ b/app/(app)/masters/workers/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 import { runAction } from '@/lib/actions/shared';
+import { ActionError } from '@/lib/actions/errors';
 import {
   workerCreateSchema,
   workerUpdateSchema,
@@ -204,7 +205,7 @@ async function findOpenAssignment(sb: SupabaseClient, workerId: string) {
     .maybeSingle();
 
   if (error) throw new Error(error.message);
-  if (!data) throw new Error('No open assignment to transfer from');
+  if (!data) throw new ActionError('No open assignment to transfer from');
   return data;
 }
 
@@ -213,10 +214,10 @@ function validateTransfer(
   input: { to_site_id: string; effective_from: string },
 ) {
   if (open.site_id === input.to_site_id) {
-    throw new Error('Destination site is the same as the current site');
+    throw new ActionError('Destination site is the same as the current site');
   }
   if (input.effective_from <= open.effective_from) {
-    throw new Error('New effective_from must be after current placement start');
+    throw new ActionError('New effective_from must be after current placement start');
   }
 }
 
@@ -241,7 +242,7 @@ async function findOpenAffiliation(sb: SupabaseClient, workerId: string) {
     .maybeSingle();
 
   if (error) throw new Error(error.message);
-  if (!data) throw new Error('No open affiliation to change from');
+  if (!data) throw new ActionError('No open affiliation to change from');
   return data;
 }
 
@@ -254,13 +255,13 @@ function validateAffiliationChange(
   },
 ) {
   if (input.effective_from <= open.effective_from) {
-    throw new Error('New effective_from must be after current affiliation start');
+    throw new ActionError('New effective_from must be after current affiliation start');
   }
   if (
     open.employment_type === input.employment_type &&
     (open.contractor_party_id ?? null) === (input.contractor_party_id ?? null)
   ) {
-    throw new Error('New affiliation is identical to the current one');
+    throw new ActionError('New affiliation is identical to the current one');
   }
 }
 

--- a/lib/actions/__tests__/errors.test.ts
+++ b/lib/actions/__tests__/errors.test.ts
@@ -5,7 +5,7 @@
  * PostgrestError objects) into short, human-safe copy.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { safeErrorMessage } from '../errors';
+import { safeErrorMessage, ActionError } from '../errors';
 
 describe('safeErrorMessage', () => {
   const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -48,6 +48,11 @@ describe('safeErrorMessage', () => {
     expect(safeErrorMessage(raw)).toBe('One or more fields are invalid.');
   });
 
+  it('maps Postgres 23P01 (exclusion_violation) to overlapping dates copy', () => {
+    const raw = { code: '23P01', message: 'conflicting key value violates exclusion constraint' };
+    expect(safeErrorMessage(raw)).toBe('A record with overlapping dates already exists.');
+  });
+
   it('returns a generic message for unknown codes', () => {
     expect(safeErrorMessage({ code: '99999', message: 'weird internal thing' })).toBe(
       'Something went wrong. Please try again.',
@@ -66,10 +71,20 @@ describe('safeErrorMessage', () => {
     expect(safeErrorMessage('boom')).toBe('Something went wrong. Please try again.');
   });
 
+  it('returns the message directly for ActionError', () => {
+    const err = new ActionError('User-safe domain message');
+    expect(safeErrorMessage(err)).toBe('User-safe domain message');
+  });
+
   it('extracts the code when it appears embedded in an Error.message (SQLSTATE ...)', () => {
     // Some pg clients stringify errors as "... SQLSTATE 42501"
     const err = new Error('something something SQLSTATE 42501');
     expect(safeErrorMessage(err)).toBe('You do not have permission to perform this action.');
+  });
+
+  it('extracts alphanumeric SQLSTATE codes like 23P01 from Error.message', () => {
+    const err = new Error('something something SQLSTATE 23P01');
+    expect(safeErrorMessage(err)).toBe('A record with overlapping dates already exists.');
   });
 
   it('logs the full error to console.error for server-side debugging', () => {
@@ -108,5 +123,10 @@ describe('safeErrorMessage', () => {
   it('recovers invalid-fields copy from not-null text when code was dropped', () => {
     const err = new Error('null value in column "site_id" of relation "purchases" violates ...');
     expect(safeErrorMessage(err)).toBe('One or more fields are invalid.');
+  });
+
+  it('recovers overlapping dates copy from exclusion text when code was dropped', () => {
+    const err = new Error('conflicting key value violates exclusion constraint "overlap"');
+    expect(safeErrorMessage(err)).toBe('A record with overlapping dates already exists.');
   });
 });

--- a/lib/actions/errors.ts
+++ b/lib/actions/errors.ts
@@ -17,6 +17,17 @@
  * reach it via `shared.ts`, which is itself `'server-only'`.
  */
 
+/**
+ * Throw this in server actions to signal that the message is safe to
+ * show to the user (e.g. domain validation failures).
+ */
+export class ActionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ActionError';
+  }
+}
+
 const MESSAGES: Record<string, string> = {
   // insufficient_privilege — raised by RLS WITH CHECK / USING denials.
   '42501': 'You do not have permission to perform this action.',
@@ -60,7 +71,7 @@ function extractCode(e: unknown): string | null {
   // Some pg wrappers stringify SQLSTATE into .message.
   if (typeof obj.message === 'string') {
     const msg = obj.message;
-    const match = msg.match(/SQLSTATE\s+(\d{5})/i);
+    const match = msg.match(/SQLSTATE\s+([A-Z0-9]{5})/i);
     if (match && match[1]) return match[1];
     for (const [re, code] of MESSAGE_PATTERNS) {
       if (re.test(msg)) return code;
@@ -72,6 +83,11 @@ function extractCode(e: unknown): string | null {
 export function safeErrorMessage(e: unknown): string {
   // Server-only log — keeps the debugging trail outside of client toasts.
   console.error('[safeErrorMessage]', e);
+
+  if (e instanceof ActionError) {
+    return e.message;
+  }
+
   const code = extractCode(e);
   if (code && code in MESSAGES) {
     const mapped = MESSAGES[code];


### PR DESCRIPTION
I have improved the error handling for the worker masters page to resolve the generic "Something went wrong" error encountered during affiliation changes and transfers.

Key changes:
1.  **ActionError Infrastructure**: I introduced a custom `ActionError` class in `lib/actions/errors.ts`. When this error is thrown in a server action, the `safeErrorMessage` utility will now pass the message directly to the client instead of masking it.
2.  **SQLSTATE Extraction Fix**: I updated the regex in `extractCode` to `/SQLSTATE\s+([A-Z0-9]{5})/i`. This correctly identifies alphanumeric Postgres error codes like `23P01` (exclusion violation), which occurs when a worker has overlapping site assignments or affiliations.
3.  **Worker Action Refactor**: I updated the validation logic in `app/(app)/masters/workers/actions.ts` to throw `ActionError` for specific domain rules (e.g., "New affiliation is identical to the current one").
4.  **Testing**: I updated the `lib/actions/__tests__/errors.test.ts` test suite to include coverage for `ActionError` and the improved SQLSTATE extraction. All tests passed.

These changes ensure that users receive helpful, specific feedback when a transaction fails due to business rule violations or database constraints.

Fixes #130

---
*PR created automatically by Jules for task [1712124894025698235](https://jules.google.com/task/1712124894025698235) started by @shubhambansal013*