### PR TITLE
Consolidate CI and Deployment triggers to prevent double runs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: CI/CD
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,6 @@
 name: CI
 on:
-  pull_request:
-    branches: [main, staging]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.gitignore'
-      - '.prettierignore'
-      - 'LICENSE'
   workflow_call:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 env:
   NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,15 +5,29 @@ on:
     branches:
       - main
       - staging
+  pull_request:
+    branches: [main, staging]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - '.prettierignore'
+      - 'LICENSE'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:
+    if: github.event_name != 'pull_request' || (github.head_ref != 'main' && github.head_ref != 'staging')
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
   check-migrations:
     needs: ci
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     name: Check for Destructive Migrations
     outputs:
@@ -89,6 +103,7 @@ jobs:
     name: Deploy to Cloudflare
     needs: [migrate-safe, migrate-destructive]
     if: |
+      github.event_name != 'pull_request' &&
       always() &&
       (needs.migrate-safe.result == 'success' || needs.migrate-destructive.result == 'success')
     environment: ${{ github.ref_name == 'main' && 'prod' || 'staging' }}
@@ -107,7 +122,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This PR addresses the issue where CI tests run twice during a PR merge (once standalone and once as part of the deployment pipeline).

By consolidating all triggers into `deploy.yml` and using job-level conditions, we ensure that CI only runs once per event, even when a PR exists between `staging` and `main`. 

Key changes:
- `ci.yml` is now a reusable workflow (`workflow_call` only).
- `deploy.yml` handles `push`, `pull_request`, and `workflow_dispatch`.
- Added an `if` condition to the `ci` job in `deploy.yml` to skip redundant `pull_request` runs if a `push` run is already triggered for the same branch.
- Gated all migration and deployment jobs to only run on `push` or `workflow_dispatch`.
- Updated `deploy.yml` to use Node.js 22.

Fixes #147

---
*PR created automatically by Jules for task [868401572447455735](https://jules.google.com/task/868401572447455735) started by @shubhambansal013*