### PR TITLE
Improve Playwright robustness and configuration

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,12 +2,17 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests/e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  retries: process.env.CI ? 2 : 1,
   use: {
     baseURL: 'http://localhost:3000',
-    trace: 'retain-on-failure',
+    actionTimeout: 15_000,
+    trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
   projects: [

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -10,6 +10,8 @@ const TEST_PASSWORD = 'test-password-1234';
 const SITE_CODE = `S-E2E-${UNIQ}`;
 
 test.describe('Golden Path', () => {
+  test.slow();
+
   let supabase: SupabaseClient;
   let testUserId: string;
   let testSiteId: string;
@@ -63,10 +65,10 @@ test.describe('Golden Path', () => {
   test('golden path: login, dashboard and transactions', async ({ page }) => {
     await test.step('Login', async () => {
       await page.goto('/login');
-      await page.fill('input[id="email"]', TEST_EMAIL);
-      await page.fill('input[id="password"]', TEST_PASSWORD);
-      await page.click('button[type="submit"]');
-      await expect(page).toHaveURL(/\/dashboard/);
+      await page.getByLabel('Email').fill(TEST_EMAIL);
+      await page.getByLabel('Password').fill(TEST_PASSWORD);
+      await page.getByRole('button', { name: /sign in with email/i }).click();
+      await page.waitForURL(/\/dashboard/, { timeout: 15_000 });
     });
 
     await test.step('Dashboard', async () => {


### PR DESCRIPTION
This change addresses the flakiness and timeout issues in Playwright E2E tests by applying several robustness patterns:

1. **Global Configuration Updates**:
   - Increased the global test timeout from 30s to 60s.
   - Increased the `expect` timeout to 10s to give more room for Next.js hydration and slow renders.
   - Set `actionTimeout` to 15s for more resilient interactions.
   - Enabled `on-first-retry` tracing to facilitate debugging in CI.
   - Increased retry counts (2 in CI, 1 locally) to mitigate transient environmental noise.

2. **Test Refactoring**:
   - Switched from ID-based selectors to robust accessibility-first locators (`getByLabel`, `getByRole`) in the login flow.
   - Replaced `expect(page).toHaveURL()` with `page.waitForURL(..., { timeout: 15000 })` to handle navigation delays more reliably.
   - Added `test.slow()` to the Golden Path suite to triple its specific timeout, as it covers multiple high-latency steps (user creation, site setup, and multi-page navigation).

These changes ensure that the E2E suite is less susceptible to minor timing variations in CI while providing better diagnostic tools when real failures occur.

Fixes #150

---
*PR created automatically by Jules for task [1848271296738357263](https://jules.google.com/task/1848271296738357263) started by @shubhambansal013*